### PR TITLE
Improve copy fallbacks and add dist artifact workflow

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,45 @@
+name: Build and Archive Dist
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: List build output
+        run: |
+          echo "Generated files:"
+          find dist -maxdepth 2 -type f -print | sort
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          if-no-files-found: error

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -64,8 +64,15 @@ const manualPromptFallback = (text: string) => {
   window.prompt("コピーできない場合は、以下のテキストを選択してコピーしてください", text);
 };
 
+const getCopyTarget = (button: HTMLButtonElement) => {
+  if (button.dataset.copyCode) return button.dataset.copyCode;
+  const codeBlock = button.previousElementSibling?.textContent?.trim();
+  if (codeBlock) return codeBlock;
+  return "";
+};
+
 const handleCopyClick = async (button: HTMLButtonElement) => {
-  const code = button.dataset.copyCode ?? "";
+  const code = getCopyTarget(button);
   const label = button.querySelector<HTMLElement>(".copy-label");
   const originalLabel = label?.textContent ?? "コピー";
 
@@ -77,6 +84,13 @@ const handleCopyClick = async (button: HTMLButtonElement) => {
       if (label) label.textContent = originalLabel;
     }, duration);
   };
+
+  if (!code) {
+    console.warn("No copy target found for copy button", button);
+    showToast("コピー対象のテキストが見つかりません", "error");
+    resetLabel(2500);
+    return;
+  }
 
   const copied = (await writeWithClipboardApi(code)) || legacyCopy(code);
 
@@ -91,6 +105,7 @@ const handleCopyClick = async (button: HTMLButtonElement) => {
     return;
   }
 
+  console.warn("Copy failed for button", button);
   showToast("コピーできませんでした。長押しで選択・コピーしてください。", "error");
   if (label) label.textContent = "コピーに失敗";
   resetLabel(2500);


### PR DESCRIPTION
## Summary
- harden the client copy helper to warn when no target text is found and surface failures
- keep copy button labels/toasts responsive even when clipboard access fails
- add a GitHub Actions job to build the site and upload the dist output for inspection

## Testing
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694946dd3ca48321be811c08a3a54f6f)