### PR TITLE
Fix base-relative assets and snippet links

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -2,6 +2,8 @@
 import type { Snippet } from "../lib/csv";
 
 const { snippet } = Astro.props as { snippet: Snippet };
+
+const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <article
   class="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 shadow-lg shadow-indigo-500/10 transition hover:-translate-y-0.5 hover:border-indigo-300/30 hover:shadow-indigo-500/30"
@@ -36,7 +38,7 @@ const { snippet } = Astro.props as { snippet: Snippet };
       <div class="flex gap-2">
         <a
           class="rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
-          href={`/snippets/${snippet.slug}/`}
+          href={withBase(`/snippets/${snippet.slug}/`)}
         >
           詳細を見る
         </a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,10 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
   description?: string;
   children?: AstroComponentFactory;
 };
+
+const resolveWithBase = (path: string) =>
+  path.startsWith("/") ? `${import.meta.env.BASE_URL}${path.slice(1)}` : path;
+const copyScriptSrc = resolveWithBase(copyScript);
 ---
 <!doctype html>
 <html lang="ja" class="scroll-smooth">
@@ -29,6 +33,6 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
       </div>
     </footer>
-    <script type="module" src={copyScript}></script>
+    <script type="module" src={copyScriptSrc}></script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,8 @@ const groupedByCategory = groupByCategory(snippets);
 const latest = [...snippets].sort(
   (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
 );
+
+const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <BaseLayout title="Astro Snippet Library" description="CSV から読み込むシンプルなスニペット集">
   <section class="grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-8 shadow-2xl shadow-indigo-500/10 backdrop-blur">
@@ -123,7 +125,7 @@ const latest = [...snippets].sort(
             <span class="rounded-full bg-white/10 px-2 py-0.5 ring-1 ring-white/10">{snippet.type}</span>
           </div>
           <a
-            href={`/snippets/${snippet.slug}/`}
+            href={withBase(`/snippets/${snippet.slug}/`)}
             class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-indigo-100 hover:text-white"
           >
             詳細を開く →
@@ -156,7 +158,7 @@ const latest = [...snippets].sort(
                   <p class="text-xs text-slate-300/80">{item.description}</p>
                 </div>
                 <a
-                  href={`/snippets/${item.slug}/`}
+                  href={withBase(`/snippets/${item.slug}/`)}
                   class="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
                 >
                   詳細

--- a/src/pages/snippets/[slug].astro
+++ b/src/pages/snippets/[slug].astro
@@ -15,6 +15,8 @@ const { snippet, snippets } = Astro.props as { snippet: Snippet; snippets: Snipp
 const related = snippets
   .filter((item) => item.category === snippet.category && item.slug !== snippet.slug)
   .slice(0, 3);
+
+const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <BaseLayout title={`${snippet.title} | Snippet`} description={snippet.description}>
   <section class="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-indigo-500/10">
@@ -30,7 +32,7 @@ const related = snippets
         </div>
       </div>
       <a
-        href="/"
+        href={withBase("/")}
         class="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
       >
         一覧へ戻る
@@ -67,7 +69,7 @@ const related = snippets
           {related.map((item) => (
             <a
               class="rounded-2xl border border-white/10 bg-slate-950/60 p-4 transition hover:-translate-y-0.5 hover:border-indigo-300/40"
-              href={`/snippets/${item.slug}/`}
+              href={withBase(`/snippets/${item.slug}/`)}
             >
               <p class="text-xs uppercase tracking-[0.2em] text-indigo-200">{item.category}</p>
               <p class="mt-1 font-semibold text-white">{item.title}</p>


### PR DESCRIPTION
## Summary
- ensure the copy script asset is loaded with the configured base path
- prefix snippet detail links with the base path to avoid 404s under GitHub Pages

## Testing
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c90f83888321ac83c3e8a43e3deb)