### PR TITLE
Bundle copy script via Astro.resolve

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,6 @@
 ---
 import type { AstroComponentFactory } from "astro";
 import "../styles/global.css";
-import copyScript from "../lib/copy.ts?url";
 
 const { title = "Astro Snippet Library", description = "Astro + Tailwind で作る静的スニペット集" } = Astro.props as {
   title?: string;
@@ -9,9 +8,7 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
   children?: AstroComponentFactory;
 };
 
-const resolveWithBase = (path: string) =>
-  path.startsWith("/") ? `${import.meta.env.BASE_URL}${path.slice(1)}` : path;
-const copyScriptSrc = resolveWithBase(copyScript);
+const copyScriptSrc = Astro.resolve("../lib/copy.ts");
 ---
 <!doctype html>
 <html lang="ja" class="scroll-smooth">


### PR DESCRIPTION
## Summary
- stop loading the copy helper as a ?url asset
- point BaseLayout to the bundled copy script via Astro.resolve to keep the copy button working

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0eda93f08321b9f6de27ebbf402d)