### PR TITLE
Inline copy script import in BaseLayout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import type { AstroComponentFactory } from "astro";
 import "../styles/global.css";
+import "../lib/copy";
 
 const { title = "Astro Snippet Library", description = "Astro + Tailwind で作る静的スニペット集" } = Astro.props as {
   title?: string;
@@ -8,7 +9,6 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
   children?: AstroComponentFactory;
 };
 
-const copyScriptSrc = Astro.resolve("../lib/copy.ts");
 ---
 <!doctype html>
 <html lang="ja" class="scroll-smooth">
@@ -30,6 +30,5 @@ const copyScriptSrc = Astro.resolve("../lib/copy.ts");
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
       </div>
     </footer>
-    <script type="module" src={copyScriptSrc}></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- import the copy helper directly in BaseLayout frontmatter
- remove Astro.resolve usage and the corresponding script tag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a120b53208321ad2b3cc2c3ab549d)