### PR TITLE
Move copy script to layout footer

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,6 @@
 ---
 import type { AstroComponentFactory } from "astro";
 import "../styles/global.css";
-import "../lib/copy";
 
 const { title = "Astro Snippet Library", description = "Astro + Tailwind で作る静的スニペット集" } = Astro.props as {
   title?: string;
@@ -30,5 +29,8 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
       </div>
     </footer>
+    <script type="module">
+      import "../lib/copy";
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move the copy helper import from the layout frontmatter to a module script before `</body>`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5a03d3ec8321890a86f12d815944)