### PR TITLE
Use Astro.resolve for copy script

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -29,8 +29,6 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
       </div>
     </footer>
-    <script type="module">
-      import "../lib/copy";
-    </script>
+    <script type="module" src={Astro.resolve("../lib/copy")}></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the copy helper via a module script tag using Astro.resolve for the path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5c7b96208321b43830291eb69e87)