### PR TITLE
Update site URL to russulasp GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  site: "https://kusano-kinoko.github.io",
+  site: "https://russulasp.github.io",
   base: "/astro-snippet-app/",
 
   vite: {


### PR DESCRIPTION
## Summary
- update Astro configuration to use the new GitHub Pages domain russulasp.github.io for site URL

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5d71c0888321be244611a54a9852)