### PR TITLE
Fix copy script loading

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,6 @@
 ---
 import type { AstroComponentFactory } from "astro";
 import "../styles/global.css";
-import copyScriptUrl from "../lib/copy.ts?url";
 
 const { title = "Astro Snippet Library", description = "Astro + Tailwind で作る静的スニペット集" } = Astro.props as {
   title?: string;
@@ -30,6 +29,8 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
       </div>
     </footer>
-    <script type="module" src={copyScriptUrl}></script>
+    <script type="module">
+      import "../lib/copy.ts";
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the copy button logic via an inline module import so it runs on the client

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a83d6b58083218d66a00a4ad9d378)