### PR TITLE
Ensure copy button script runs on client

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -29,8 +29,6 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
       </div>
     </footer>
-    <script type="module">
-      import "../lib/copy.ts";
-    </script>
+    <script type="module" src="/scripts/copy.client.ts"></script>
   </body>
 </html>

--- a/src/scripts/copy.client.ts
+++ b/src/scripts/copy.client.ts
@@ -1,0 +1,1 @@
+import "../lib/copy";


### PR DESCRIPTION
## Summary
- add a client entry script that imports the copy logic
- load the new client script from the base layout so copy buttons initialize in the browser

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a86e06090832198c1173b117d201f)