### PR TITLE
Add build timestamp to layout footer

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,6 +7,8 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
   description?: string;
   children?: AstroComponentFactory;
 };
+const buildTimestamp = new Date();
+const buildTimestampLabel = buildTimestamp.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
 
 ---
 <!doctype html>
@@ -27,6 +29,7 @@ const { title = "Astro Snippet Library", description = "Astro + Tailwind で作�
       <div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/80">
         <p class="font-semibold text-white">Astro Snippet Library</p>
         <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
+        <p class="mt-4 text-xs text-slate-200/60">Build: {buildTimestampLabel} (JST)</p>
       </div>
     </footer>
     <script type="module" src="/scripts/copy.client.ts"></script>


### PR DESCRIPTION
### Motivation

- Make it obvious when the site was last built so repository updates and CI rebuilds can be verified from the page itself.
- Provide a human-readable build time in JST so reviewers can quickly confirm deployment freshness.

### Description

- Added `buildTimestamp` and `buildTimestampLabel` to `src/layouts/BaseLayout.astro` and format it with `toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })`.
- Render the build label in the footer as `Build: {buildTimestampLabel} (JST)` with small, muted text styles.
- Only a single file was modified: `src/layouts/BaseLayout.astro`.

### Testing

- Launched the dev server with `pnpm dev` and the server reported ready (succeeded).
- Verified the page responded with `HTTP/1.1 200 OK` using `curl -I` (succeeded).
- Attempted to capture a screenshot with Playwright but the browser connection failed with `ERR_CONNECTION_REFUSED` (failed).
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b170eddbc832197ef6001e8a822b2)