### PR TITLE
Serve copy button script from public assets

### DIFF
--- a/public/scripts/copy.client.js
+++ b/public/scripts/copy.client.js
@@ -1,0 +1,116 @@
+const ensureToastContainer = () => {
+  let container = document.querySelector("#copy-toast-container");
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "copy-toast-container";
+    container.className = "pointer-events-none fixed top-5 right-5 z-50 flex flex-col gap-2";
+    document.body.appendChild(container);
+  }
+  return container;
+};
+
+const showToast = (message, variant = "success") => {
+  const container = ensureToastContainer();
+  const toast = document.createElement("div");
+  toast.textContent = message;
+  toast.className = `pointer-events-auto rounded-full px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-black/20 transition duration-200 ${variant === "error" ? "bg-red-500" : "bg-emerald-500"}`;
+  container.appendChild(toast);
+
+  requestAnimationFrame(() => {
+    toast.classList.add("opacity-100");
+  });
+
+  setTimeout(() => {
+    toast.classList.add("opacity-0", "translate-y-1");
+  }, 1500);
+
+  setTimeout(() => {
+    toast.remove();
+  }, 2000);
+};
+
+const writeWithClipboardApi = async (text) => {
+  if (!navigator.clipboard || !navigator.clipboard.writeText) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const legacyCopy = (text) => {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch (error) {
+    copied = false;
+  }
+
+  document.body.removeChild(textarea);
+  return copied;
+};
+
+const manualPromptFallback = (text) => {
+  window.prompt("コピーできない場合は、以下のテキストを選択してコピーしてください", text);
+};
+
+const handleCopyClick = async (button) => {
+  const code = button.dataset.copyCode ?? "";
+  const label = button.querySelector(".copy-label");
+  const originalLabel = label?.textContent ?? "コピー";
+
+  if (label) label.textContent = "Copying...";
+  let resetTimer = 0;
+  const resetLabel = (duration) => {
+    window.clearTimeout(resetTimer);
+    resetTimer = window.setTimeout(() => {
+      if (label) label.textContent = originalLabel;
+    }, duration);
+  };
+
+  const copied = (await writeWithClipboardApi(code)) || legacyCopy(code);
+
+  if (copied) {
+    if (label) label.textContent = "Copied!";
+    button.classList.add("ring", "ring-emerald-300/40");
+    showToast("Copied!");
+    resetLabel(2000);
+    setTimeout(() => {
+      button.classList.remove("ring", "ring-emerald-300/40");
+    }, 2000);
+    return;
+  }
+
+  showToast("コピーできませんでした。長押しで選択・コピーしてください。", "error");
+  if (label) label.textContent = "コピーに失敗";
+  resetLabel(2500);
+  manualPromptFallback(code);
+};
+
+const setupCopyButtons = () => {
+  const copyButtons = document.querySelectorAll(".copy-btn");
+  copyButtons.forEach((button) => {
+    if (button.dataset.copyBound === "true") return;
+    button.dataset.copyBound = "true";
+    button.addEventListener("click", () => handleCopyClick(button));
+  });
+};
+
+const initCopyButtons = () => {
+  setupCopyButtons();
+};
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", initCopyButtons);
+  document.addEventListener("astro:page-load", initCopyButtons);
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -32,6 +32,6 @@ const buildTimestampLabel = buildTimestamp.toLocaleString("ja-JP", { timeZone: "
         <p class="mt-4 text-xs text-slate-200/60">Build: {buildTimestampLabel} (JST)</p>
       </div>
     </footer>
-    <script type="module" src="/scripts/copy.client.ts"></script>
+    <script src={`${import.meta.env.BASE_URL}scripts/copy.client.js`}></script>
   </body>
 </html>

--- a/src/scripts/copy.client.ts
+++ b/src/scripts/copy.client.ts
@@ -1,1 +1,0 @@
-import "../lib/copy";


### PR DESCRIPTION
### Motivation
- Ensure the copy button script runs in production on GitHub Pages without Vite/Astro bundling or MIME type issues from `?url` imports.
- Serve a plain JavaScript file directly from `public/` so the browser executes raw JS rather than relying on TypeScript transpilation.
- Make the script work under a non-root `base` by resolving its path with `import.meta.env.BASE_URL`.
- Prevent double-loading and remove any runtime reliance on `src`-side module imports for side effects.

### Description
- Added `public/scripts/copy.client.js`, a plain JavaScript translation of the existing `src/lib/copy.ts` logic, keeping `toast`, Clipboard API usage, legacy fallback, and `DOMContentLoaded`/`astro:page-load` initialization intact.
- Updated `src/layouts/BaseLayout.astro` to load the script with `<script src={`${import.meta.env.BASE_URL}scripts/copy.client.js`}></script>` so the path respects the configured base URL.
- Removed `src/scripts/copy.client.ts` to avoid importing the client logic via the Astro/Vite pipeline and to prevent double-loading.
- No functional changes to the copy behavior itself (labels, toasts, clipboard fallbacks, and event binding remain as before).

### Testing
- No automated tests were run as part of this change.
- Local build/commit performed successfully (files added/removed and layout updated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1cb6f3a4832193e954cf299ecc61)