### PR TITLE
Remove hero section from home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,45 +14,6 @@ const latest = [...snippets].sort(
 const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <BaseLayout title="Astro Snippet Library" description="CSV から読み込むシンプルなスニペット集">
-  <section class="grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-8 shadow-2xl shadow-indigo-500/10 backdrop-blur">
-    <p class="inline-flex items-center gap-2 rounded-full bg-indigo-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-100 ring-1 ring-indigo-400/40">
-      Astro + Tailwind + CSV
-    </p>
-    <div class="grid items-center gap-10 lg:grid-cols-[1.4fr_1fr]">
-      <div class="space-y-6">
-        <h1 class="text-4xl font-black leading-tight tracking-tight sm:text-5xl">
-          小さなスニペットを<br />
-          すばやく探してコピー。
-        </h1>
-        <p class="max-w-2xl text-lg text-slate-200/90">
-          CSV に保存したコマンドや Tips を静的サイトで検索・閲覧できます。カテゴリーやタイプで絞り込み、必要なコードをワンクリックでコピー。
-        </p>
-        <div class="flex flex-wrap gap-3 text-sm text-slate-200/80">
-          <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">GitHub Pages / Cloudflare Pages に最適</span>
-          <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">サーバーレスで完結</span>
-          <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">コピー用スクリプト付き</span>
-        </div>
-      </div>
-      <div class="space-y-4 rounded-2xl border border-white/10 bg-slate-950/60 p-6 shadow-inner">
-        <p class="text-xs uppercase tracking-[0.2em] text-indigo-200">サンプル</p>
-        <div class="grid gap-3 text-sm font-mono text-indigo-100">
-          <div class="rounded-xl border border-white/10 bg-slate-900/80 p-4">
-            <p class="text-indigo-200">docker run hello-world</p>
-          </div>
-          <button
-            class="copy-btn inline-flex w-full items-center justify-center gap-2 rounded-full bg-indigo-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
-            type="button"
-            data-copy-code="docker run hello-world"
-          >
-            <span aria-hidden="true">📋</span>
-            <span class="copy-label">このコマンドをコピー</span>
-          </button>
-          <p class="text-xs text-slate-300/80">CSV の code 列をそのままクリップボードへコピーします。</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <section class="grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-indigo-500/10">
     <div class="flex flex-wrap items-center gap-4">
       <div>


### PR DESCRIPTION
### Motivation
- Remove the top hero section from the home page to simplify and shorten the landing content.
- The change implements a request to delete the very first section in `src/pages/index.astro` that contained the headline, description, and sample copy button.
- Keep the focus of the page on the search and snippet listing areas.

### Description
- Deleted the initial hero `<section>` block from `src/pages/index.astro`, removing the hero headline, description, badges, and sample copy button.
- No other source files were modified and the remaining sections, components, and client-side filtering script are unchanged.
- A visual verification artifact (screenshot) was produced to confirm the hero is no longer rendered.

### Testing
- Started the dev server with `pnpm exec astro dev --host 0.0.0.0 --port 4321`, and the server came up successfully.
- Confirmed the page responded with `HTTP/1.1 200 OK` using `curl -I`, which succeeded.
- Captured a full-page screenshot with Playwright saved as `artifacts/index-no-hero.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694caa407fc08321b2118683f80d7853)