### PR TITLE
Remove latest and category sections from home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,11 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import SnippetCard from "../components/SnippetCard.astro";
-import { groupByCategory, loadSnippets } from "../lib/csv";
+import { loadSnippets } from "../lib/csv";
 
 const snippets = loadSnippets();
 const categories = Array.from(new Set(snippets.map((snippet) => snippet.category)));
 const types = Array.from(new Set(snippets.map((snippet) => snippet.type)));
-const groupedByCategory = groupByCategory(snippets);
-const latest = [...snippets].sort(
-  (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-);
-
-const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <BaseLayout title="Astro Snippet Library" description="CSV から読み込むシンプルなスニペット集">
   <section class="grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-indigo-500/10">
@@ -58,76 +52,6 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
     <div id="snippet-list" class="grid gap-4 sm:grid-cols-2">
       {snippets.map((snippet) => (
         <SnippetCard snippet={snippet} />
-      ))}
-    </div>
-  </section>
-
-  <section class="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-indigo-500/10">
-    <div class="flex items-center justify-between">
-      <div>
-        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-200">Latest</p>
-        <h2 class="text-2xl font-bold">最近更新されたスニペット</h2>
-      </div>
-      <a
-        href="#search"
-        class="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
-      >
-        すべてを見る
-      </a>
-    </div>
-    <div class="grid gap-4 md:grid-cols-3">
-      {latest.slice(0, 3).map((snippet) => (
-        <article class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-          <p class="text-xs uppercase tracking-[0.2em] text-indigo-200">{snippet.category}</p>
-          <h3 class="mt-2 text-lg font-semibold text-white">{snippet.title}</h3>
-          <p class="text-sm text-slate-200/80">{snippet.description}</p>
-          <div class="mt-3 flex flex-wrap gap-2 text-xs text-slate-200/80">
-            <span class="rounded-full bg-white/10 px-2 py-0.5 ring-1 ring-white/10">更新日 {snippet.updated_at}</span>
-            <span class="rounded-full bg-white/10 px-2 py-0.5 ring-1 ring-white/10">{snippet.type}</span>
-          </div>
-          <a
-            href={withBase(`/snippets/${snippet.slug}/`)}
-            class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-indigo-100 hover:text-white"
-          >
-            詳細を開く →
-          </a>
-        </article>
-      ))}
-    </div>
-  </section>
-
-  <section class="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-indigo-500/10">
-    <div class="flex items-center justify-between">
-      <div>
-        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-200">Category</p>
-        <h2 class="text-2xl font-bold">カテゴリー別のスニペット</h2>
-      </div>
-      <span class="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold ring-1 ring-white/10">{categories.length} カテゴリー</span>
-    </div>
-    <div class="grid gap-3 md:grid-cols-2">
-      {Object.entries(groupedByCategory).map(([category, items]) => (
-        <article class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-          <div class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold">{category}</h3>
-            <span class="rounded-full bg-indigo-500/20 px-3 py-1 text-xs font-semibold text-indigo-50 ring-1 ring-indigo-300/40">{items.length} 件</span>
-          </div>
-          <ul class="mt-3 space-y-2 text-sm text-slate-200/85">
-            {items.map((item) => (
-              <li class="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-                <div>
-                  <p class="font-semibold text-white">{item.title}</p>
-                  <p class="text-xs text-slate-300/80">{item.description}</p>
-                </div>
-                <a
-                  href={withBase(`/snippets/${item.slug}/`)}
-                  class="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
-                >
-                  詳細
-                </a>
-              </li>
-            ))}
-          </ul>
-        </article>
       ))}
     </div>
   </section>


### PR DESCRIPTION
### Motivation
- Simplify the home page by removing the "最近更新されたスニペット" (Latest) and "カテゴリー別のスニペット" (Category) sections.  
- Remove associated data preparation and helpers that are no longer needed for the simplified view.  

### Description
- Deleted the markup for the Latest and Category sections from `src/pages/index.astro`.  
- Removed import and usage of `groupByCategory` and removed the `latest`/`groupedByCategory` calculations in `src/pages/index.astro`.  
- Dropped the now-unused `withBase` helper and updated imports to only use `loadSnippets` from `../lib/csv`.  

### Testing
- Started the dev server with `pnpm dev -- --host 0.0.0.0 --port 4321` and the server launched successfully.  
- Captured a full-page screenshot via the Playwright script which completed and produced an artifact.  
- No unit or integration test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb3a7781083218cfd297e2b71b5ec)