### PR TITLE
Fix view toggle script in Astro page (remove TypeScript annotations)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -145,14 +145,14 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
 
   <script type="module">
     document.addEventListener("DOMContentLoaded", () => {
-      const searchInput = document.querySelector<HTMLInputElement>("#search");
-      const categorySelect = document.querySelector<HTMLSelectElement>("#category");
-      const typeSelect = document.querySelector<HTMLSelectElement>("#type");
-      const cards = Array.from(document.querySelectorAll<HTMLElement>("[data-snippet]"));
-      const resultCount = document.querySelector<HTMLElement>("#result-count");
-      const viewButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-view-toggle]"));
-      const cardList = document.querySelector<HTMLElement>("#snippet-list");
-      const tableList = document.querySelector<HTMLElement>("#snippet-table");
+      const searchInput = document.querySelector("#search");
+      const categorySelect = document.querySelector("#category");
+      const typeSelect = document.querySelector("#type");
+      const cards = Array.from(document.querySelectorAll("[data-snippet]"));
+      const resultCount = document.querySelector("#result-count");
+      const viewButtons = Array.from(document.querySelectorAll("[data-view-toggle]"));
+      const cardList = document.querySelector("#snippet-list");
+      const tableList = document.querySelector("#snippet-table");
 
       const applyFilters = () => {
         const keyword = searchInput?.value.trim().toLowerCase() ?? "";
@@ -179,7 +179,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
         }
       };
 
-      const setView = (view: "card" | "table") => {
+      const setView = (view) => {
         cardList?.classList.toggle("hidden", view !== "card");
         tableList?.classList.toggle("hidden", view !== "table");
         viewButtons.forEach((button) => {


### PR DESCRIPTION
### Motivation
- The inline `<script type="module">` contained TypeScript-only type annotations which prevent the script from running as plain JavaScript in the Astro runtime.
- This caused UI controls like the view toggle between card and table to not respond correctly.

### Description
- Removed TypeScript generic annotations from `querySelector` and `querySelectorAll` calls and converted them to plain selectors in `src/pages/index.astro`.
- Changed the typed `setView` signature `view: "card" | "table"` to an untyped `view` parameter so the inline script is valid JS.
- Kept original behavior for applying filters and toggling the card/table views intact.

### Testing
- No automated tests were run as part of this change.
- Manual smoke validation was performed by ensuring the script parses as plain JavaScript and the view toggle logic is unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f8aaa22d88321bebf38f0917cec96)