### PR TITLE
Show empty state and reset filters when search yields no results

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -133,6 +133,23 @@ const modalSnippets = snippets.map((snippet) => ({
         </table>
       </div>
     </div>
+
+    <div
+      id="empty-state"
+      class="hidden rounded-3xl border border-dashed border-white/15 bg-slate-950/40 px-6 py-10 text-center text-sm text-slate-200/80"
+      role="status"
+      aria-live="polite"
+    >
+      <p class="text-base font-semibold text-white">一致するスニペットが見つかりませんでした。</p>
+      <p class="mt-2 text-slate-200/70">検索条件を変えるか、リセットして再度お試しください。</p>
+      <button
+        type="button"
+        id="reset-filters"
+        class="mt-5 inline-flex items-center justify-center rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
+      >
+        条件をリセット
+      </button>
+    </div>
   </section>
 
   <div class="fixed inset-x-0 bottom-4 z-20 mx-auto flex w-[calc(100%-2rem)] max-w-sm items-center justify-center gap-2 rounded-full border border-white/10 bg-slate-950/80 p-2 text-xs font-semibold text-white shadow-lg shadow-indigo-500/30 backdrop-blur sm:hidden">
@@ -229,6 +246,8 @@ const modalSnippets = snippets.map((snippet) => ({
       const viewButtons = Array.from(document.querySelectorAll("[data-view-toggle]"));
       const cardList = document.querySelector("#snippet-list");
       const tableList = document.querySelector("#snippet-table");
+      const emptyState = document.querySelector("#empty-state");
+      const resetButton = document.querySelector("#reset-filters");
 
       const applyFilters = () => {
         const keyword = searchInput?.value.trim().toLowerCase() ?? "";
@@ -253,6 +272,10 @@ const modalSnippets = snippets.map((snippet) => ({
         if (resultCount) {
           resultCount.textContent = `${visible} 件ヒット`;
         }
+
+        if (emptyState) {
+          emptyState.classList.toggle("hidden", visible !== 0);
+        }
       };
 
       const setView = (view) => {
@@ -268,6 +291,12 @@ const modalSnippets = snippets.map((snippet) => ({
       };
 
       [searchInput, categorySelect, typeSelect].forEach((el) => el?.addEventListener("input", applyFilters));
+      resetButton?.addEventListener("click", () => {
+        if (searchInput) searchInput.value = "";
+        if (categorySelect) categorySelect.value = "";
+        if (typeSelect) typeSelect.value = "";
+        applyFilters();
+      });
       viewButtons.forEach((button) => {
         button.addEventListener("click", () => {
           const view = button.dataset.view === "table" ? "table" : "card";


### PR DESCRIPTION
### Motivation
- Improve the empty / no-hit UX by providing explicit guidance when a search returns zero snippets.
- Current UI only updates a hit count, which can be unclear when nothing matches filters.
- Provide an accessible status message and an easy way to clear filters to reduce user friction.

### Description
- Add a new `#empty-state` block with messaging, a `#reset-filters` button, `role="status"`, and `aria-live="polite"` for screen readers.
- Wire up `emptyState` and `resetButton` DOM references in the page script and toggle visibility from `applyFilters` based on the visible count.
- Implement a reset handler that clears `#search`, `#category`, and `#type` inputs and calls `applyFilters`.
- Update the result count text logic to remain in sync with the empty-state visibility.

### Testing
- Started the dev server with `pnpm dev` and verified the application served pages successfully.
- Ran a Playwright script that fills `#search` with a no-match keyword and captured `artifacts/empty-state.png` to confirm the empty state rendered (succeeded).
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e02b879c8321828f7f6c646ffe33)