### PR TITLE
Enhance copy UX with highlights and shortcut hints

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -15,6 +15,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
   data-category={snippet.category}
   data-type={snippet.type}
   data-display="flex"
+  data-copy-scope
 >
   <header class="flex items-start justify-between gap-3">
     <div>
@@ -27,7 +28,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
     </span>
   </header>
   <div class="grid gap-3 text-sm font-mono text-indigo-100">
-    <div class="rounded-xl border border-white/10 bg-slate-950/60 p-4">
+    <div class="rounded-xl border border-white/10 bg-slate-950/60 p-4 transition duration-300" data-copy-highlight>
       <pre class="whitespace-pre-wrap">{snippet.code}</pre>
     </div>
     <div class="flex flex-wrap items-center justify-between gap-3">
@@ -36,7 +37,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
           <span class="rounded-full bg-white/10 px-2 py-0.5 text-[11px] font-semibold text-indigo-50 ring-1 ring-white/10">{tag}</span>
         ))}
       </div>
-      <div class="flex gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <a
           class="rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
           href={withBase(`/snippets/${snippet.slug}/`)}
@@ -45,14 +46,17 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
         >
           詳細を見る
         </a>
-        <button
-          class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-3 py-1.5 text-xs font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
-          type="button"
-          data-copy-code={snippet.code}
-        >
-          <span aria-hidden="true">📋</span>
-          <span class="copy-label">コピー</span>
-        </button>
+        <div class="flex items-center gap-2">
+          <button
+            class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-3 py-1.5 text-xs font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
+            type="button"
+            data-copy-code={snippet.code}
+          >
+            <span aria-hidden="true">📋</span>
+            <span class="copy-label">コピー</span>
+          </button>
+          <span class="text-[10px] font-semibold text-slate-200/70">⌘/Ctrl + C</span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -64,6 +64,29 @@ const manualPromptFallback = (text: string) => {
   window.prompt("コピーできない場合は、以下のテキストを選択してコピーしてください", text);
 };
 
+const highlightTimeouts = new WeakMap<HTMLElement, number>();
+
+const highlightCodeBlock = (button: HTMLButtonElement) => {
+  const scope = button.closest<HTMLElement>("[data-copy-scope]") ?? document.body;
+  const target = scope.querySelector<HTMLElement>("[data-copy-highlight]");
+  if (!target) return;
+
+  const existingTimeout = highlightTimeouts.get(target);
+  if (existingTimeout) window.clearTimeout(existingTimeout);
+
+  target.classList.add("ring-2", "ring-emerald-400/60", "bg-emerald-500/10", "shadow-lg", "shadow-emerald-500/20");
+  const timeout = window.setTimeout(() => {
+    target.classList.remove(
+      "ring-2",
+      "ring-emerald-400/60",
+      "bg-emerald-500/10",
+      "shadow-lg",
+      "shadow-emerald-500/20",
+    );
+  }, 2000);
+  highlightTimeouts.set(target, timeout);
+};
+
 const handleCopyClick = async (button: HTMLButtonElement) => {
   const code = button.dataset.copyCode ?? "";
   const label = button.querySelector<HTMLElement>(".copy-label");
@@ -83,6 +106,7 @@ const handleCopyClick = async (button: HTMLButtonElement) => {
   if (copied) {
     if (label) label.textContent = "Copied!";
     button.classList.add("ring", "ring-emerald-300/40");
+    highlightCodeBlock(button);
     showToast("Copied!");
     resetLabel(2000);
     setTimeout(() => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -201,22 +201,26 @@ const modalSnippets = snippets.map((snippet) => ({
         <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">更新日 <span id="snippet-modal-updated"></span></span>
       </div>
 
-      <div class="grid gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-5">
-        <div class="flex items-center justify-between gap-3">
+      <div class="grid gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-5" data-copy-scope>
+        <div class="flex flex-wrap items-center justify-between gap-3">
           <p class="text-sm font-semibold text-white">code</p>
-          <button
-            class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
-            type="button"
-            id="snippet-modal-copy"
-            data-copy-code=""
-          >
-            <span aria-hidden="true">📋</span>
-            <span class="copy-label">コピー</span>
-          </button>
+          <div class="flex items-center gap-3">
+            <span class="text-xs font-semibold text-slate-200/70">⌘/Ctrl + C</span>
+            <button
+              class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
+              type="button"
+              id="snippet-modal-copy"
+              data-copy-code=""
+            >
+              <span aria-hidden="true">📋</span>
+              <span class="copy-label">コピー</span>
+            </button>
+          </div>
         </div>
         <pre
           id="snippet-modal-code"
-          class="whitespace-pre-wrap rounded-xl border border-white/10 bg-slate-900/80 p-4 text-sm font-mono text-indigo-100"
+          class="whitespace-pre-wrap rounded-xl border border-white/10 bg-slate-900/80 p-4 text-sm font-mono text-indigo-100 transition duration-300"
+          data-copy-highlight
         ></pre>
         <div id="snippet-modal-tags" class="flex flex-wrap gap-2"></div>
       </div>

--- a/src/pages/snippets/[slug].astro
+++ b/src/pages/snippets/[slug].astro
@@ -39,19 +39,27 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
       </a>
     </div>
 
-    <div class="grid gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-5">
-      <div class="flex items-center justify-between gap-3">
+    <div class="grid gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-5" data-copy-scope>
+      <div class="flex flex-wrap items-center justify-between gap-3">
         <p class="text-sm font-semibold text-white">code</p>
-        <button
-          class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
-          type="button"
-          data-copy-code={snippet.code}
-        >
-          <span aria-hidden="true">📋</span>
-          <span class="copy-label">コピー</span>
-        </button>
+        <div class="flex items-center gap-3">
+          <span class="text-xs font-semibold text-slate-200/70">⌘/Ctrl + C</span>
+          <button
+            class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
+            type="button"
+            data-copy-code={snippet.code}
+          >
+            <span aria-hidden="true">📋</span>
+            <span class="copy-label">コピー</span>
+          </button>
+        </div>
       </div>
-      <pre class="rounded-xl border border-white/10 bg-slate-900/80 p-4 text-sm font-mono text-indigo-100 whitespace-pre-wrap">{snippet.code}</pre>
+      <pre
+        class="rounded-xl border border-white/10 bg-slate-900/80 p-4 text-sm font-mono text-indigo-100 whitespace-pre-wrap transition duration-300"
+        data-copy-highlight
+      >
+        {snippet.code}
+      </pre>
       <div class="flex flex-wrap gap-2">
         {snippet.tags.map((tag) => (
           <span class="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-indigo-50 ring-1 ring-white/10">{tag}</span>


### PR DESCRIPTION
### Motivation

- Improve the perceived "copy completed" feedback by adding a visual highlight to the code block in addition to the existing toast message. 
- Surface the common keyboard shortcut so users know they can use `⌘/Ctrl + C` as an alternative to the copy button. 
- Limit the highlight to the appropriate scope so card/modal/detail copy behavior is consistent and non-intrusive. 

### Description

- Add a scoped highlight system in `src/lib/copy.ts` using a `WeakMap` and a new `highlightCodeBlock` helper that toggles utility classes on a target element for 2s. 
- Invoke the highlight on successful copy inside the existing `handleCopyClick` flow and preserve the existing toast/label behavior. 
- Mark copy containers and targets by adding `data-copy-scope` to snippet containers and `data-copy-highlight` to code blocks, and add `transition`/`duration-300` classes for smooth animation. 
- Add small copy shortcut hints (`⌘/Ctrl + C`) next to copy buttons in `src/components/SnippetCard.astro`, `src/pages/index.astro` (modal), and `src/pages/snippets/[slug].astro` (detail). 

### Testing

- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4321`, which launched the Astro dev server successfully. 
- Attempted to capture a UI screenshot with Playwright to verify the highlight, but the Playwright navigation failed with `net::ERR_EMPTY_RESPONSE` so the visual check did not complete. 
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e3d36ef08321989cc690063395fb)