### PR TITLE
Fix snippet hit count display

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -14,6 +14,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
   data-code={snippet.code.toLowerCase()}
   data-category={snippet.category}
   data-type={snippet.type}
+  data-snippet-id={snippet.slug}
   data-display="flex"
   data-copy-scope
 >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -110,6 +110,7 @@ const modalSnippets = snippets.map((snippet) => ({
                 data-code={snippet.code.toLowerCase()}
                 data-category={snippet.category}
                 data-type={snippet.type}
+                data-snippet-id={snippet.slug}
                 data-display="table-row"
               >
                 <td class="px-4 py-3 font-semibold text-white">{snippet.title}</td>
@@ -258,7 +259,7 @@ const modalSnippets = snippets.map((snippet) => ({
         const category = categorySelect?.value ?? "";
         const type = typeSelect?.value ?? "";
 
-        let visible = 0;
+        const visibleSnippets = new Set();
         cards.forEach((card) => {
           const matchesKeyword = keyword
             ? ["title", "description", "tags", "code"].some((field) =>
@@ -270,15 +271,17 @@ const modalSnippets = snippets.map((snippet) => ({
           const show = matchesKeyword && matchesCategory && matchesType;
           const display = card.dataset.display ?? "block";
           card.style.display = show ? display : "none";
-          if (show) visible += 1;
+          if (show && card.dataset.snippetId) {
+            visibleSnippets.add(card.dataset.snippetId);
+          }
         });
 
         if (resultCount) {
-          resultCount.textContent = `${visible} 件ヒット`;
+          resultCount.textContent = `${visibleSnippets.size} 件ヒット`;
         }
 
         if (emptyState) {
-          emptyState.classList.toggle("hidden", visible !== 0);
+          emptyState.classList.toggle("hidden", visibleSnippets.size !== 0);
         }
       };
 


### PR DESCRIPTION
### Motivation
- The search hit total could be inflated because the same snippet was represented by multiple DOM elements and counted multiple times.  
- A stable identifier is needed on each snippet element so client-side filtering can dedupe results.  
- Update the filter logic to report the correct unique snippet count in the UI.  

### Description
- Added `data-snippet-id={snippet.slug}` to snippet elements in `src/components/SnippetCard.astro` and the table rows in `src/pages/index.astro`.  
- Replaced the numeric `visible` counter with a `Set` (`visibleSnippets`) that collects `card.dataset.snippetId` for shown cards to avoid double-counting.  
- Updated the result text and empty-state toggle to use `visibleSnippets.size` for the hit total and emptiness check.  
- Modified files: `src/components/SnippetCard.astro` and `src/pages/index.astro`.  

### Testing
- No automated tests were executed as part of this change.  
- Verified code compiles locally via the development toolchain (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951eb2d269083219b811335cc0f4b1d)