### PR TITLE
Adjust snippet card and table density

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -28,10 +28,20 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
       {snippet.type}
     </span>
   </header>
-  <div class="grid gap-3 text-sm font-mono text-indigo-100">
-    <div class="rounded-xl border border-white/10 bg-slate-950/60 p-4 transition duration-300" data-copy-highlight>
-      <pre class="whitespace-pre-wrap">{snippet.code}</pre>
-    </div>
+  <div class="grid gap-3 text-sm text-indigo-100">
+    <details class="group rounded-xl border border-white/10 bg-slate-950/60 p-4 transition duration-300" data-copy-highlight>
+      <summary class="flex cursor-pointer items-center justify-between text-xs font-semibold text-indigo-200">
+        <span>コードプレビュー (最大6行)</span>
+        <span class="rounded-full bg-white/10 px-2 py-0.5 text-[11px] text-indigo-50 ring-1 ring-white/10 group-open:hidden">
+          展開
+        </span>
+        <span class="hidden rounded-full bg-white/10 px-2 py-0.5 text-[11px] text-indigo-50 ring-1 ring-white/10 group-open:inline">
+          折りたたむ
+        </span>
+      </summary>
+      <pre class="mt-3 max-h-36 overflow-hidden whitespace-pre-wrap font-mono group-open:max-h-none">{snippet.code}</pre>
+      <p class="mt-2 text-[11px] text-slate-200/70">全文は詳細で閲覧できます。</p>
+    </details>
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex flex-wrap gap-2">
         {snippet.tags.map((tag) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,6 +95,8 @@ const modalSnippets = snippets.map((snippet) => ({
               <th scope="col" class="px-4 py-3">Title</th>
               <th scope="col" class="px-4 py-3">Category</th>
               <th scope="col" class="px-4 py-3">Type</th>
+              <th scope="col" class="px-4 py-3">Tags</th>
+              <th scope="col" class="px-4 py-3">Preview</th>
               <th scope="col" class="px-4 py-3">Updated</th>
               <th scope="col" class="px-4 py-3"></th>
             </tr>
@@ -116,6 +118,25 @@ const modalSnippets = snippets.map((snippet) => ({
                 <td class="px-4 py-3 font-semibold text-white">{snippet.title}</td>
                 <td class="px-4 py-3 text-indigo-100/90">{snippet.category}</td>
                 <td class="px-4 py-3">{snippet.type}</td>
+                <td class="px-4 py-3">
+                  <div class="flex flex-wrap gap-1.5">
+                    {snippet.tags.slice(0, 3).map((tag) => (
+                      <span class="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-indigo-50 ring-1 ring-white/10">
+                        {tag}
+                      </span>
+                    ))}
+                    {snippet.tags.length > 3 && (
+                      <span class="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-slate-200/70 ring-1 ring-white/10">
+                        +{snippet.tags.length - 3}
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  <p class="line-clamp-1 max-w-[240px] font-mono text-xs text-indigo-100/90">
+                    {snippet.code.split("\n")[0]}
+                  </p>
+                </td>
                 <td class="px-4 py-3 text-slate-300/80">{snippet.updated_at}</td>
                 <td class="px-4 py-3 text-right">
                   <a


### PR DESCRIPTION
### Motivation
- Reduce visual density in lists while preserving readable code on cards by differentiating card (overview) and table (list) roles.
- Make card code easier to scan without occupying too much vertical space by collapsing long code blocks.
- Improve table utility for quick scanning by surfacing tags and a compact code preview.
- Provide a clear affordance to view full code on the detail page.

### Description
- Replace the full code block in `src/components/SnippetCard.astro` with a `<details>`/`<summary>` toggle and a `pre` that uses `max-h-36` to limit initial height and `group-open:max-h-none` to expand when opened.
- Add helper text in the card indicating full code is available on the detail page and keep the existing copy button behavior (`data-copy-code`).
- Add `Tags` and `Preview` columns to the table in `src/pages/index.astro`, showing up to three tags with a `+N` indicator for overflow and a single-line code preview using the first line of `snippet.code` with `line-clamp-1`.
- Keep existing detail navigation (`data-snippet-open`) and filtering behavior intact by preserving the snippet dataset attributes used by the page script.

### Testing
- Started the dev server with `npm run dev` and the site served locally at `/astro-snippet-app/` successfully.
- Verified HTTP response with `curl -I http://127.0.0.1:4321/astro-snippet-app/` which returned `HTTP/1.1 200 OK`.
- Attempted automated UI screenshot using Playwright, but navigation/screenshot failed due to headless Chromium errors (`ERR_EMPTY_RESPONSE` / SIGSEGV) and did not produce a screenshot.
- No unit tests were added or run as this is a UI/markup change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951f48ae96c8321847978b86b537de0)