### PR TITLE
Add tag filters and sorting to snippet search

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -14,6 +14,8 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
   data-code={snippet.code.toLowerCase()}
   data-category={snippet.category}
   data-type={snippet.type}
+  data-created={snippet.created_at}
+  data-updated={snippet.updated_at}
   data-snippet-id={snippet.slug}
   data-display="flex"
   data-copy-scope

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,9 @@ import { loadSnippets } from "../lib/csv";
 const snippets = loadSnippets();
 const categories = Array.from(new Set(snippets.map((snippet) => snippet.category)));
 const types = Array.from(new Set(snippets.map((snippet) => snippet.type)));
+const tags = Array.from(new Set(snippets.flatMap((snippet) => snippet.tags))).sort((a, b) =>
+  a.localeCompare(b, "ja"),
+);
 const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 const modalSnippets = snippets.map((snippet) => ({
   slug: snippet.slug,
@@ -51,7 +54,7 @@ const modalSnippets = snippets.map((snippet) => ({
         </div>
       </div>
     </div>
-    <div class="grid gap-3 sm:grid-cols-[2fr_1fr_1fr]">
+    <div class="grid gap-3 sm:grid-cols-[2fr_1fr_1fr_1fr]">
       <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">🔍</span>
         <input
@@ -79,6 +82,32 @@ const modalSnippets = snippets.map((snippet) => ({
           ))}
         </select>
       </label>
+      <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
+        <span class="text-indigo-200">#</span>
+        <select id="tag" class="w-full bg-transparent text-sm outline-none">
+          <option value="">すべてのタグ</option>
+          {tags.map((tag) => (
+            <option value={tag}>{tag}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+
+    <div class="grid gap-3 sm:grid-cols-[1fr_2fr]">
+      <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
+        <span class="text-indigo-200">↕️</span>
+        <select id="sort" class="w-full bg-transparent text-sm outline-none">
+          <option value="updated_desc">更新日が新しい順</option>
+          <option value="updated_asc">更新日が古い順</option>
+          <option value="created_desc">作成日が新しい順</option>
+          <option value="created_asc">作成日が古い順</option>
+          <option value="title_asc">タイトル A-Z</option>
+          <option value="title_desc">タイトル Z-A</option>
+        </select>
+      </label>
+      <p class="flex items-center rounded-xl border border-dashed border-white/10 bg-slate-950/30 px-4 py-2 text-xs text-slate-200/70">
+        タグの選択や並び替えを組み合わせて、目的のスニペットを素早く見つけられます。
+      </p>
     </div>
 
     <div id="snippet-list" class="grid gap-4 sm:grid-cols-2">
@@ -112,6 +141,8 @@ const modalSnippets = snippets.map((snippet) => ({
                 data-code={snippet.code.toLowerCase()}
                 data-category={snippet.category}
                 data-type={snippet.type}
+                data-created={snippet.created_at}
+                data-updated={snippet.updated_at}
                 data-snippet-id={snippet.slug}
                 data-display="table-row"
               >
@@ -283,18 +314,73 @@ const modalSnippets = snippets.map((snippet) => ({
       const searchInput = document.querySelector("#search");
       const categorySelect = document.querySelector("#category");
       const typeSelect = document.querySelector("#type");
-      const cards = Array.from(document.querySelectorAll("[data-snippet]"));
+      const tagSelect = document.querySelector("#tag");
+      const sortSelect = document.querySelector("#sort");
+      const cardItems = Array.from(document.querySelectorAll("#snippet-list [data-snippet]"));
+      const tableItems = Array.from(document.querySelectorAll("#snippet-table [data-snippet]"));
+      const cards = [...cardItems, ...tableItems];
       const resultCount = document.querySelector("#result-count");
       const viewButtons = Array.from(document.querySelectorAll("[data-view-toggle]"));
       const cardList = document.querySelector("#snippet-list");
       const tableList = document.querySelector("#snippet-table");
+      const tableBody = document.querySelector("#snippet-table tbody");
       const emptyState = document.querySelector("#empty-state");
       const resetButton = document.querySelector("#reset-filters");
+
+      const toTimestamp = (value) => {
+        const time = Date.parse(value ?? "");
+        return Number.isNaN(time) ? 0 : time;
+      };
+
+      const sortItems = () => {
+        const sortValue = sortSelect?.value ?? "updated_desc";
+        const compare = (a, b) => {
+          switch (sortValue) {
+            case "updated_asc":
+              return (a.updatedAt ?? 0) - (b.updatedAt ?? 0);
+            case "created_desc":
+              return (b.createdAt ?? 0) - (a.createdAt ?? 0);
+            case "created_asc":
+              return (a.createdAt ?? 0) - (b.createdAt ?? 0);
+            case "title_desc":
+              return (b.title ?? "").localeCompare(a.title ?? "", "ja");
+            case "title_asc":
+              return (a.title ?? "").localeCompare(b.title ?? "", "ja");
+            case "updated_desc":
+            default:
+              return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+          }
+        };
+
+        const sortedCards = cardItems
+          .map((item) => ({
+            item,
+            title: item.dataset.title ?? "",
+            createdAt: toTimestamp(item.dataset.created),
+            updatedAt: toTimestamp(item.dataset.updated),
+          }))
+          .sort(compare)
+          .map((entry) => entry.item);
+
+        const sortedRows = tableItems
+          .map((item) => ({
+            item,
+            title: item.dataset.title ?? "",
+            createdAt: toTimestamp(item.dataset.created),
+            updatedAt: toTimestamp(item.dataset.updated),
+          }))
+          .sort(compare)
+          .map((entry) => entry.item);
+
+        sortedCards.forEach((item) => cardList?.appendChild(item));
+        sortedRows.forEach((item) => tableBody?.appendChild(item));
+      };
 
       const applyFilters = () => {
         const keyword = searchInput?.value.trim().toLowerCase() ?? "";
         const category = categorySelect?.value ?? "";
         const type = typeSelect?.value ?? "";
+        const tag = tagSelect?.value.toLowerCase() ?? "";
 
         const visibleSnippets = new Set();
         cards.forEach((card) => {
@@ -305,7 +391,8 @@ const modalSnippets = snippets.map((snippet) => ({
             : true;
           const matchesCategory = category ? card.dataset.category === category : true;
           const matchesType = type ? card.dataset.type === type : true;
-          const show = matchesKeyword && matchesCategory && matchesType;
+          const matchesTag = tag ? card.dataset.tags?.includes(tag) : true;
+          const show = matchesKeyword && matchesCategory && matchesType && matchesTag;
           const display = card.dataset.display ?? "block";
           card.style.display = show ? display : "none";
           if (show && card.dataset.snippetId) {
@@ -320,6 +407,8 @@ const modalSnippets = snippets.map((snippet) => ({
         if (emptyState) {
           emptyState.classList.toggle("hidden", visibleSnippets.size !== 0);
         }
+
+        sortItems();
       };
 
       const setView = (view) => {
@@ -334,11 +423,15 @@ const modalSnippets = snippets.map((snippet) => ({
         });
       };
 
-      [searchInput, categorySelect, typeSelect].forEach((el) => el?.addEventListener("input", applyFilters));
+      [searchInput, categorySelect, typeSelect, tagSelect, sortSelect].forEach((el) =>
+        el?.addEventListener("input", applyFilters),
+      );
       resetButton?.addEventListener("click", () => {
         if (searchInput) searchInput.value = "";
         if (categorySelect) categorySelect.value = "";
         if (typeSelect) typeSelect.value = "";
+        if (tagSelect) tagSelect.value = "";
+        if (sortSelect) sortSelect.value = "updated_desc";
         applyFilters();
       });
       viewButtons.forEach((button) => {


### PR DESCRIPTION
### Motivation

- Improve snippet discoverability by adding tag-based filtering and explicit sorting options to the search UI. 
- Allow combining keyword, category, type, and tag filters so users can narrow results more precisely. 
- Provide common sorting choices (updated/created date and title order) so relevant snippets surface first.

### Description

- Add a computed `tags` list (sorted with `localeCompare`) and render a `#` `select` with id `tag` as a new filter control. 
- Add a `sort` `select` control with options (`updated_desc`, `updated_asc`, `created_desc`, `created_asc`, `title_asc`, `title_desc`) and a `sortItems` function that reorders card and table DOM elements. 
- Expose `data-created` and `data-updated` attributes on snippet cards and table rows and parse them to timestamps for stable date sorting. 
- Extend `applyFilters` to include tag matching and wire `tag`/`sort` inputs to the same event handlers, plus reset behavior for the new controls.

### Testing

- Started the dev server with `pnpm dev` and the server reported ready and content synced (Astro ready). 
- Performed a basic HTTP health check with `curl -I` against `http://localhost:4321/astro-snippet-app/` which returned `HTTP/1.1 200 OK`. 
- Attempted automated page screenshots with Playwright but the runs failed with `net::ERR_EMPTY_RESPONSE` and subsequent Chromium launch errors (SIGSEGV), so visual verification via Playwright could not complete. 
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695204f06ea48321ac9ba6afb72a7841)