### PR TITLE
Add clear buttons for search filters

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,6 +63,14 @@ const modalSnippets = snippets.map((snippet) => ({
           placeholder="キーワード (タイトル・説明・タグ・コード)"
           class="w-full bg-transparent text-sm outline-none placeholder:text-slate-400"
         />
+        <button
+          type="button"
+          data-clear-field="search"
+          class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[11px] font-semibold text-white/80 transition hover:border-indigo-200/50 hover:bg-white/20"
+          aria-label="キーワードをクリア"
+        >
+          クリア
+        </button>
       </label>
       <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">📁</span>
@@ -72,6 +80,14 @@ const modalSnippets = snippets.map((snippet) => ({
             <option value={category}>{category}</option>
           ))}
         </select>
+        <button
+          type="button"
+          data-clear-field="category"
+          class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[11px] font-semibold text-white/80 transition hover:border-indigo-200/50 hover:bg-white/20"
+          aria-label="カテゴリーをクリア"
+        >
+          クリア
+        </button>
       </label>
       <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">🏷️</span>
@@ -81,6 +97,14 @@ const modalSnippets = snippets.map((snippet) => ({
             <option value={type}>{type}</option>
           ))}
         </select>
+        <button
+          type="button"
+          data-clear-field="type"
+          class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[11px] font-semibold text-white/80 transition hover:border-indigo-200/50 hover:bg-white/20"
+          aria-label="タイプをクリア"
+        >
+          クリア
+        </button>
       </label>
       <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">#</span>
@@ -90,6 +114,14 @@ const modalSnippets = snippets.map((snippet) => ({
             <option value={tag}>{tag}</option>
           ))}
         </select>
+        <button
+          type="button"
+          data-clear-field="tag"
+          class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[11px] font-semibold text-white/80 transition hover:border-indigo-200/50 hover:bg-white/20"
+          aria-label="タグをクリア"
+        >
+          クリア
+        </button>
       </label>
     </div>
 
@@ -108,6 +140,15 @@ const modalSnippets = snippets.map((snippet) => ({
       <p class="flex items-center rounded-xl border border-dashed border-white/10 bg-slate-950/30 px-4 py-2 text-xs text-slate-200/70">
         タグの選択や並び替えを組み合わせて、目的のスニペットを素早く見つけられます。
       </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        id="clear-all-filters"
+        class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
+      >
+        すべての入力をクリア
+      </button>
     </div>
 
     <div id="snippet-list" class="grid gap-4 sm:grid-cols-2">
@@ -326,6 +367,8 @@ const modalSnippets = snippets.map((snippet) => ({
       const tableBody = document.querySelector("#snippet-table tbody");
       const emptyState = document.querySelector("#empty-state");
       const resetButton = document.querySelector("#reset-filters");
+      const clearButtons = Array.from(document.querySelectorAll("[data-clear-field]"));
+      const clearAllButton = document.querySelector("#clear-all-filters");
 
       const toTimestamp = (value) => {
         const time = Date.parse(value ?? "");
@@ -427,6 +470,36 @@ const modalSnippets = snippets.map((snippet) => ({
         el?.addEventListener("input", applyFilters),
       );
       resetButton?.addEventListener("click", () => {
+        if (searchInput) searchInput.value = "";
+        if (categorySelect) categorySelect.value = "";
+        if (typeSelect) typeSelect.value = "";
+        if (tagSelect) tagSelect.value = "";
+        if (sortSelect) sortSelect.value = "updated_desc";
+        applyFilters();
+      });
+      clearButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const field = button.dataset.clearField;
+          switch (field) {
+            case "search":
+              if (searchInput) searchInput.value = "";
+              break;
+            case "category":
+              if (categorySelect) categorySelect.value = "";
+              break;
+            case "type":
+              if (typeSelect) typeSelect.value = "";
+              break;
+            case "tag":
+              if (tagSelect) tagSelect.value = "";
+              break;
+            default:
+              break;
+          }
+          applyFilters();
+        });
+      });
+      clearAllButton?.addEventListener("click", () => {
         if (searchInput) searchInput.value = "";
         if (categorySelect) categorySelect.value = "";
         if (typeSelect) typeSelect.value = "";


### PR DESCRIPTION
### Motivation
- Provide per-field clear controls and a global clear-all to improve the search/filter UX for snippets. 
- Ensure clearing any input immediately re-applies filters so results and counts stay in sync.

### Description
- Added per-field clear buttons next to the search input and `select` elements with `data-clear-field` attributes for `search`, `category`, `type`, and `tag`.
- Added a global clear button with the id `#clear-all-filters` that resets all inputs and the `sort` selection.
- Wired up client-side handlers: collect elements with `document.querySelectorAll("[data-clear-field]")` and `#clear-all-filters`, reset the corresponding inputs, and call `applyFilters()` to refresh the view.
- Kept the existing reset logic for the `#reset-filters` button and reused `applyFilters()` to maintain consistent behavior.

### Testing
- Started the dev server with `npm run dev` and the Astro dev server reported ready and served the app (server process ran).
- Attempted to capture a UI screenshot via Playwright to validate the added buttons, but Playwright crashed and the screenshot step failed.
- No unit or integration tests were added or run as part of this change.
- The code change was committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521196c4948321b73e1a50eca07f1f)