### PR TITLE
Show actual code in snippet card summary and limit preview to three lines

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -32,8 +32,10 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
   </header>
   <div class="grid gap-3 text-sm text-indigo-100">
     <details class="group rounded-xl border border-white/10 bg-slate-950/60 p-4 transition duration-300" data-copy-highlight>
-      <summary class="flex cursor-pointer items-center justify-between text-xs font-semibold text-indigo-200">
-        <span>コードプレビュー (最大6行)</span>
+      <summary class="flex cursor-pointer items-start justify-between gap-3 text-xs font-semibold text-indigo-200">
+        <pre class="max-h-12 flex-1 overflow-hidden whitespace-pre-wrap font-mono text-[11px] font-normal leading-4 text-indigo-100">
+{snippet.code}
+        </pre>
         <span class="rounded-full bg-white/10 px-2 py-0.5 text-[11px] text-indigo-50 ring-1 ring-white/10 group-open:hidden">
           展開
         </span>
@@ -41,7 +43,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
           折りたたむ
         </span>
       </summary>
-      <pre class="mt-3 max-h-36 overflow-hidden whitespace-pre-wrap font-mono group-open:max-h-none">{snippet.code}</pre>
+      <pre class="mt-3 whitespace-pre-wrap font-mono">{snippet.code}</pre>
       <p class="mt-2 text-[11px] text-slate-200/70">全文は詳細で閲覧できます。</p>
     </details>
     <div class="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
### Motivation
- Replace the placeholder "コードプレビュー (最大6行)" label with an actual code excerpt so the card shows real code by default. 
- Limit the default inline preview height to roughly three lines to reduce visual noise on the snippet list. 
- Keep the details expandable so the full snippet is still accessible from the card. 

### Description
- Updated `src/components/SnippetCard.astro` to render `snippet.code` inside a `pre` in the `summary` area instead of the static label. 
- Constrained the inline preview using `max-h-12`, `flex-1`, `overflow-hidden`, and adjusted typography classes for a compact three-line appearance. 
- Simplified the expanded view by removing the previous `max-h-36` / `group-open:max-h-none` collapse logic and letting the main `pre` display the full code when opened. 

### Testing
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 4321`, which launched successfully. 
- Verified the app responded with `HTTP/1.1 200 OK` using `curl -I http://127.0.0.1:4321/astro-snippet-app/`. 
- Attempted automated screenshot capture with Playwright, but the `Page.goto` calls failed with `net::ERR_EMPTY_RESPONSE`, so screenshots were not produced. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695215f18a388321a63b8462c7d99c32)