### PR TITLE
Dynamically update category/type dropdowns to reflect current filter results

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -369,6 +369,7 @@ const modalSnippets = snippets.map((snippet) => ({
       const resetButton = document.querySelector("#reset-filters");
       const clearButtons = Array.from(document.querySelectorAll("[data-clear-field]"));
       const clearAllButton = document.querySelector("#clear-all-filters");
+      const snippetDataElement = document.querySelector("#snippet-data");
 
       const toTimestamp = (value) => {
         const time = Date.parse(value ?? "");
@@ -419,11 +420,97 @@ const modalSnippets = snippets.map((snippet) => ({
         sortedRows.forEach((item) => tableBody?.appendChild(item));
       };
 
+      const snippets = snippetDataElement?.textContent ? JSON.parse(snippetDataElement.textContent) : [];
+      const snippetMap = new Map(snippets.map((snippet) => [snippet.slug, snippet]));
+      const preparedSnippets = snippets.map((snippet) => ({
+        ...snippet,
+        searchText: [snippet.title, snippet.description, snippet.code, snippet.tags.join(" ")]
+          .join(" ")
+          .toLowerCase(),
+        tagText: snippet.tags.join(" ").toLowerCase(),
+      }));
+
+      const buildFilterState = () => ({
+        keyword: searchInput?.value.trim().toLowerCase() ?? "",
+        category: categorySelect?.value ?? "",
+        type: typeSelect?.value ?? "",
+        tag: tagSelect?.value.toLowerCase() ?? "",
+      });
+
+      const updateSelectOptions = (select, placeholder, options, currentValue) => {
+        if (!select) return currentValue;
+        const sorted = Array.from(options).sort((a, b) => a.localeCompare(b, "ja"));
+        const nextValue = options.has(currentValue) ? currentValue : "";
+        const optionNodes = [
+          Object.assign(document.createElement("option"), {
+            value: "",
+            textContent: placeholder,
+          }),
+          ...sorted.map((value) =>
+            Object.assign(document.createElement("option"), {
+              value,
+              textContent: value,
+              selected: value === nextValue,
+            }),
+          ),
+        ];
+        select.replaceChildren(...optionNodes);
+        if (select.value !== nextValue) select.value = nextValue;
+        return nextValue;
+      };
+
+      const updateFilterOptions = (state) => {
+        const refreshOptions = (currentState) => {
+          const keywordMatch = (snippet) =>
+            currentState.keyword ? snippet.searchText.includes(currentState.keyword) : true;
+          const tagMatch = (snippet) =>
+            currentState.tag ? snippet.tagText.includes(currentState.tag) : true;
+          const typeMatch = (snippet) =>
+            currentState.type ? snippet.type === currentState.type : true;
+          const categoryMatch = (snippet) =>
+            currentState.category ? snippet.category === currentState.category : true;
+
+          const availableCategories = new Set(
+            preparedSnippets
+              .filter((snippet) => keywordMatch(snippet) && typeMatch(snippet) && tagMatch(snippet))
+              .map((snippet) => snippet.category),
+          );
+          const availableTypes = new Set(
+            preparedSnippets
+              .filter((snippet) => keywordMatch(snippet) && categoryMatch(snippet) && tagMatch(snippet))
+              .map((snippet) => snippet.type),
+          );
+
+          const nextCategory = updateSelectOptions(
+            categorySelect,
+            "すべてのカテゴリー",
+            availableCategories,
+            currentState.category,
+          );
+          const nextType = updateSelectOptions(
+            typeSelect,
+            "すべてのタイプ",
+            availableTypes,
+            currentState.type,
+          );
+
+          return {
+            ...currentState,
+            category: nextCategory,
+            type: nextType,
+          };
+        };
+
+        let nextState = refreshOptions(state);
+        if (nextState.category !== state.category || nextState.type !== state.type) {
+          nextState = refreshOptions(nextState);
+        }
+        return nextState;
+      };
+
       const applyFilters = () => {
-        const keyword = searchInput?.value.trim().toLowerCase() ?? "";
-        const category = categorySelect?.value ?? "";
-        const type = typeSelect?.value ?? "";
-        const tag = tagSelect?.value.toLowerCase() ?? "";
+        const state = updateFilterOptions(buildFilterState());
+        const { keyword, category, type, tag } = state;
 
         const visibleSnippets = new Set();
         cards.forEach((card) => {
@@ -515,7 +602,6 @@ const modalSnippets = snippets.map((snippet) => ({
       });
 
       const snippetModal = document.querySelector("#snippet-modal");
-      const snippetDataElement = document.querySelector("#snippet-data");
       const modalTitle = document.querySelector("#snippet-modal-title");
       const modalDescription = document.querySelector("#snippet-modal-description");
       const modalCategory = document.querySelector("#snippet-modal-category");
@@ -530,9 +616,6 @@ const modalSnippets = snippets.map((snippet) => ({
       const modalCopy = document.querySelector("#snippet-modal-copy");
       const modalLink = document.querySelector("#snippet-modal-link");
       const modalClose = document.querySelector("[data-modal-close]");
-
-      const snippets = snippetDataElement?.textContent ? JSON.parse(snippetDataElement.textContent) : [];
-      const snippetMap = new Map(snippets.map((snippet) => [snippet.slug, snippet]));
 
       const renderRelatedSnippets = (currentSnippet) => {
         if (!modalRelated || !modalRelatedCount) return;


### PR DESCRIPTION
### Motivation
- Keep the category and type dropdown options always consistent with the currently applied filters so users cannot pick combinations that would return zero results. 
- Avoid showing options that are impossible given the current keyword/tag/type/category state to improve UX and reduce confusion. 
- Preserve existing UI and behavior while updating the select lists automatically as filters change. 

### Description
- Added client-side preprocessing (`preparedSnippets`) to combine snippet fields into searchable text and tag text for quicker matching. 
- Introduced `buildFilterState`, `updateSelectOptions`, and `updateFilterOptions` helpers to recompute available categories and types and to clear invalid selections. 
- Modified `applyFilters` to call `updateFilterOptions(buildFilterState())` and use the returned state for filtering, and double-refresh logic ensures selections stay consistent when one change affects the other. 
- Minor DOM hookup: read `#snippet-data` earlier and move `snippetMap` initialization to the top-level of the module where needed by modals. 

### Testing
- No automated tests were run against these changes. 
- Manual smoke testing in the browser was used during development to verify dropdown options update when typing/searching and when clearing filters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521ca807dc83219ddc6883eb98c888)