### PR TITLE
Remove tag-based search from snippets page

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -10,7 +10,6 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
   data-snippet
   data-title={snippet.title.toLowerCase()}
   data-description={snippet.description.toLowerCase()}
-  data-tags={snippet.tags.join(" ").toLowerCase()}
   data-code={snippet.code.toLowerCase()}
   data-category={snippet.category}
   data-type={snippet.type}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,9 +6,6 @@ import { loadSnippets } from "../lib/csv";
 const snippets = loadSnippets();
 const categories = Array.from(new Set(snippets.map((snippet) => snippet.category)));
 const types = Array.from(new Set(snippets.map((snippet) => snippet.type)));
-const tags = Array.from(new Set(snippets.flatMap((snippet) => snippet.tags))).sort((a, b) =>
-  a.localeCompare(b, "ja"),
-);
 const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 const modalSnippets = snippets.map((snippet) => ({
   slug: snippet.slug,
@@ -54,13 +51,13 @@ const modalSnippets = snippets.map((snippet) => ({
         </div>
       </div>
     </div>
-    <div class="grid gap-3 sm:grid-cols-[2fr_1fr_1fr_1fr]">
+    <div class="grid gap-3 sm:grid-cols-[2fr_1fr_1fr]">
       <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">🔍</span>
         <input
           id="search"
           type="search"
-          placeholder="キーワード (タイトル・説明・タグ・コード)"
+          placeholder="キーワード (タイトル・説明・コード)"
           class="w-full bg-transparent text-sm outline-none placeholder:text-slate-400"
         />
         <button
@@ -106,23 +103,6 @@ const modalSnippets = snippets.map((snippet) => ({
           クリア
         </button>
       </label>
-      <label class="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
-        <span class="text-indigo-200">#</span>
-        <select id="tag" class="w-full bg-transparent text-sm outline-none">
-          <option value="">すべてのタグ</option>
-          {tags.map((tag) => (
-            <option value={tag}>{tag}</option>
-          ))}
-        </select>
-        <button
-          type="button"
-          data-clear-field="tag"
-          class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[11px] font-semibold text-white/80 transition hover:border-indigo-200/50 hover:bg-white/20"
-          aria-label="タグをクリア"
-        >
-          クリア
-        </button>
-      </label>
     </div>
 
     <div class="grid gap-3 sm:grid-cols-[1fr_2fr]">
@@ -138,7 +118,7 @@ const modalSnippets = snippets.map((snippet) => ({
         </select>
       </label>
       <p class="flex items-center rounded-xl border border-dashed border-white/10 bg-slate-950/30 px-4 py-2 text-xs text-slate-200/70">
-        タグの選択や並び替えを組み合わせて、目的のスニペットを素早く見つけられます。
+        カテゴリーやタイプ、並び替えを組み合わせて目的のスニペットを素早く見つけられます。
       </p>
     </div>
     <div class="flex flex-wrap items-center gap-2">
@@ -178,7 +158,6 @@ const modalSnippets = snippets.map((snippet) => ({
                 data-snippet
                 data-title={snippet.title.toLowerCase()}
                 data-description={snippet.description.toLowerCase()}
-                data-tags={snippet.tags.join(" ").toLowerCase()}
                 data-code={snippet.code.toLowerCase()}
                 data-category={snippet.category}
                 data-type={snippet.type}
@@ -321,14 +300,6 @@ const modalSnippets = snippets.map((snippet) => ({
 
       <div class="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-5">
         <div class="flex items-center justify-between">
-          <h3 class="text-sm font-semibold text-white">タグで再検索</h3>
-          <span class="text-xs text-slate-200/70">クリックで検索条件に追加</span>
-        </div>
-        <div id="snippet-modal-tag-actions" class="flex flex-wrap gap-2"></div>
-      </div>
-
-      <div class="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-5">
-        <div class="flex items-center justify-between">
           <h3 class="text-sm font-semibold text-white">関連スニペット</h3>
           <span id="snippet-modal-related-count" class="text-xs text-slate-200/70"></span>
         </div>
@@ -355,7 +326,6 @@ const modalSnippets = snippets.map((snippet) => ({
       const searchInput = document.querySelector("#search");
       const categorySelect = document.querySelector("#category");
       const typeSelect = document.querySelector("#type");
-      const tagSelect = document.querySelector("#tag");
       const sortSelect = document.querySelector("#sort");
       const cardItems = Array.from(document.querySelectorAll("#snippet-list [data-snippet]"));
       const tableItems = Array.from(document.querySelectorAll("#snippet-table [data-snippet]"));
@@ -424,20 +394,14 @@ const modalSnippets = snippets.map((snippet) => ({
       const snippetMap = new Map(snippets.map((snippet) => [snippet.slug, snippet]));
       const preparedSnippets = snippets.map((snippet) => ({
         ...snippet,
-        searchText: [snippet.title, snippet.description, snippet.code, snippet.tags.join(" ")]
-          .join(" ")
-          .toLowerCase(),
-        tagText: snippet.tags.join(" ").toLowerCase(),
+        searchText: [snippet.title, snippet.description, snippet.code].join(" ").toLowerCase(),
       }));
 
       const buildFilterState = () => {
-        const tagValue = tagSelect?.value ?? "";
         return {
           keyword: searchInput?.value.trim().toLowerCase() ?? "",
           category: categorySelect?.value ?? "",
           type: typeSelect?.value ?? "",
-          tag: tagValue,
-          tagLower: tagValue.toLowerCase(),
         };
       };
 
@@ -467,8 +431,6 @@ const modalSnippets = snippets.map((snippet) => ({
         const refreshOptions = (currentState) => {
           const keywordMatch = (snippet) =>
             currentState.keyword ? snippet.searchText.includes(currentState.keyword) : true;
-          const tagMatch = (snippet) =>
-            currentState.tagLower ? snippet.tagText.includes(currentState.tagLower) : true;
           const typeMatch = (snippet) =>
             currentState.type ? snippet.type === currentState.type : true;
           const categoryMatch = (snippet) =>
@@ -476,18 +438,13 @@ const modalSnippets = snippets.map((snippet) => ({
 
           const availableCategories = new Set(
             preparedSnippets
-              .filter((snippet) => keywordMatch(snippet) && typeMatch(snippet) && tagMatch(snippet))
+              .filter((snippet) => keywordMatch(snippet) && typeMatch(snippet))
               .map((snippet) => snippet.category),
           );
           const availableTypes = new Set(
             preparedSnippets
-              .filter((snippet) => keywordMatch(snippet) && categoryMatch(snippet) && tagMatch(snippet))
+              .filter((snippet) => keywordMatch(snippet) && categoryMatch(snippet))
               .map((snippet) => snippet.type),
-          );
-          const availableTags = new Set(
-            preparedSnippets
-              .filter((snippet) => keywordMatch(snippet) && categoryMatch(snippet) && typeMatch(snippet))
-              .flatMap((snippet) => snippet.tags),
           );
 
           const nextCategory = updateSelectOptions(
@@ -502,22 +459,18 @@ const modalSnippets = snippets.map((snippet) => ({
             availableTypes,
             currentState.type,
           );
-          const nextTag = updateSelectOptions(tagSelect, "すべてのタグ", availableTags, currentState.tag);
 
           return {
             ...currentState,
             category: nextCategory,
             type: nextType,
-            tag: nextTag,
-            tagLower: nextTag.toLowerCase(),
           };
         };
 
         let nextState = refreshOptions(state);
         if (
           nextState.category !== state.category ||
-          nextState.type !== state.type ||
-          nextState.tag !== state.tag
+          nextState.type !== state.type
         ) {
           nextState = refreshOptions(nextState);
         }
@@ -526,19 +479,16 @@ const modalSnippets = snippets.map((snippet) => ({
 
       const applyFilters = () => {
         const state = updateFilterOptions(buildFilterState());
-        const { keyword, category, type, tagLower } = state;
+        const { keyword, category, type } = state;
 
         const visibleSnippets = new Set();
         cards.forEach((card) => {
           const matchesKeyword = keyword
-            ? ["title", "description", "tags", "code"].some((field) =>
-                card.dataset[field]?.includes(keyword),
-              )
+            ? ["title", "description", "code"].some((field) => card.dataset[field]?.includes(keyword))
             : true;
           const matchesCategory = category ? card.dataset.category === category : true;
           const matchesType = type ? card.dataset.type === type : true;
-          const matchesTag = tagLower ? card.dataset.tags?.includes(tagLower) : true;
-          const show = matchesKeyword && matchesCategory && matchesType && matchesTag;
+          const show = matchesKeyword && matchesCategory && matchesType;
           const display = card.dataset.display ?? "block";
           card.style.display = show ? display : "none";
           if (show && card.dataset.snippetId) {
@@ -569,14 +519,13 @@ const modalSnippets = snippets.map((snippet) => ({
         });
       };
 
-      [searchInput, categorySelect, typeSelect, tagSelect, sortSelect].forEach((el) =>
+      [searchInput, categorySelect, typeSelect, sortSelect].forEach((el) =>
         el?.addEventListener("input", applyFilters),
       );
       resetButton?.addEventListener("click", () => {
         if (searchInput) searchInput.value = "";
         if (categorySelect) categorySelect.value = "";
         if (typeSelect) typeSelect.value = "";
-        if (tagSelect) tagSelect.value = "";
         if (sortSelect) sortSelect.value = "updated_desc";
         applyFilters();
       });
@@ -593,9 +542,6 @@ const modalSnippets = snippets.map((snippet) => ({
             case "type":
               if (typeSelect) typeSelect.value = "";
               break;
-            case "tag":
-              if (tagSelect) tagSelect.value = "";
-              break;
             default:
               break;
           }
@@ -606,7 +552,6 @@ const modalSnippets = snippets.map((snippet) => ({
         if (searchInput) searchInput.value = "";
         if (categorySelect) categorySelect.value = "";
         if (typeSelect) typeSelect.value = "";
-        if (tagSelect) tagSelect.value = "";
         if (sortSelect) sortSelect.value = "updated_desc";
         applyFilters();
       });
@@ -626,7 +571,6 @@ const modalSnippets = snippets.map((snippet) => ({
       const modalUpdated = document.querySelector("#snippet-modal-updated");
       const modalCode = document.querySelector("#snippet-modal-code");
       const modalTags = document.querySelector("#snippet-modal-tags");
-      const modalTagActions = document.querySelector("#snippet-modal-tag-actions");
       const modalRelated = document.querySelector("#snippet-modal-related");
       const modalRelatedCount = document.querySelector("#snippet-modal-related-count");
       const modalCopy = document.querySelector("#snippet-modal-copy");
@@ -678,20 +622,6 @@ const modalSnippets = snippets.map((snippet) => ({
         });
       };
 
-      const renderTagActions = (snippet) => {
-        if (!modalTagActions) return;
-        modalTagActions.innerHTML = "";
-        snippet.tags.forEach((tag) => {
-          const tagButton = document.createElement("button");
-          tagButton.type = "button";
-          tagButton.dataset.tagSearch = tag;
-          tagButton.className =
-            "rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20";
-          tagButton.textContent = `#${tag}`;
-          modalTagActions.appendChild(tagButton);
-        });
-      };
-
       const bindOpenButtons = (root = document) => {
         const openButtons = Array.from(root.querySelectorAll("[data-snippet-open]"));
         openButtons.forEach((button) => {
@@ -730,7 +660,6 @@ const modalSnippets = snippets.map((snippet) => ({
           });
         }
 
-        renderTagActions(snippet);
         renderRelatedSnippets(snippet);
         bindOpenButtons(snippetModal);
 
@@ -744,19 +673,6 @@ const modalSnippets = snippets.map((snippet) => ({
       };
 
       bindOpenButtons();
-
-      modalTagActions?.addEventListener("click", (event) => {
-        const target = event.target;
-        if (!(target instanceof HTMLElement)) return;
-        const tag = target.dataset.tagSearch;
-        if (!tag) return;
-        if (searchInput) {
-          searchInput.value = tag;
-          applyFilters();
-        }
-        closeModal();
-        searchInput?.focus();
-      });
 
       modalClose?.addEventListener("click", closeModal);
       snippetModal?.addEventListener("click", (event) => {


### PR DESCRIPTION
### Motivation
- The snippets page should no longer offer tag-based searching in the UI while preserving tag data for potential future use. 
- Tag selection, tag-based filtering, and tag-driven modal actions were deemed unnecessary for the current page experience. 
- Keep tag display on cards/tables/modals so tags remain visible without being used as search inputs. 

### Description
- Removed the tag select UI and related options and placeholder generation from `src/pages/index.astro`. 
- Removed tag-based filtering logic and references including `tagSelect`, `tagText`, `availableTags`, and `data-tags` attributes, and simplified `searchText` to cover only `title`, `description`, and `code`. 
- Removed modal tag-action buttons and their click handlers so clicking tags no longer updates search state, while keeping tag rendering in the modal and cards. 
- Updated UI text and layout (search placeholder and helper copy) and removed `data-tags` from `src/components/SnippetCard.astro` to stop relying on tags for filtering. 

### Testing
- Started a local dev server with `pnpm dev` as a smoke test and the server reported ready and accessible on `localhost:4321`, which succeeded. 
- Attempted an automated Playwright screenshot run to validate the UI, but Chromium crashed (SIGSEGV) and the Playwright run failed. 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695322c231cc83219085252e3ab3f78b)