### PR TITLE
Adjust table layout for mobile and add per-row copy button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -139,16 +139,17 @@ const modalSnippets = snippets.map((snippet) => ({
 
     <div id="snippet-table" class="hidden">
       <div class="overflow-x-auto rounded-2xl border border-white/10 bg-slate-950/40">
-        <table class="min-w-full text-left text-sm text-slate-200/85">
+        <table class="w-full min-w-full text-left text-sm text-slate-200/85">
           <thead class="bg-white/5 text-xs uppercase tracking-[0.2em] text-indigo-200">
             <tr>
               <th scope="col" class="px-4 py-3">Title</th>
-              <th scope="col" class="px-4 py-3">Category</th>
-              <th scope="col" class="px-4 py-3">Type</th>
-              <th scope="col" class="px-4 py-3">Tags</th>
+              <th scope="col" class="hidden px-4 py-3 sm:table-cell">Category</th>
+              <th scope="col" class="hidden px-4 py-3 sm:table-cell">Type</th>
+              <th scope="col" class="hidden px-4 py-3 sm:table-cell">Tags</th>
               <th scope="col" class="px-4 py-3">Preview</th>
-              <th scope="col" class="px-4 py-3">Updated</th>
-              <th scope="col" class="px-4 py-3"></th>
+              <th scope="col" class="hidden px-4 py-3 sm:table-cell">Updated</th>
+              <th scope="col" class="px-4 py-3 text-right sm:text-left">Copy</th>
+              <th scope="col" class="px-4 py-3 text-right"></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-white/5">
@@ -165,11 +166,12 @@ const modalSnippets = snippets.map((snippet) => ({
                 data-updated={snippet.updated_at}
                 data-snippet-id={snippet.slug}
                 data-display="table-row"
+                data-copy-scope
               >
                 <td class="px-4 py-3 font-semibold text-white">{snippet.title}</td>
-                <td class="px-4 py-3 text-indigo-100/90">{snippet.category}</td>
-                <td class="px-4 py-3">{snippet.type}</td>
-                <td class="px-4 py-3">
+                <td class="hidden px-4 py-3 text-indigo-100/90 sm:table-cell">{snippet.category}</td>
+                <td class="hidden px-4 py-3 sm:table-cell">{snippet.type}</td>
+                <td class="hidden px-4 py-3 sm:table-cell">
                   <div class="flex flex-wrap gap-1.5">
                     {snippet.tags.slice(0, 3).map((tag) => (
                       <span class="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold text-indigo-50 ring-1 ring-white/10">
@@ -184,11 +186,24 @@ const modalSnippets = snippets.map((snippet) => ({
                   </div>
                 </td>
                 <td class="px-4 py-3">
-                  <p class="line-clamp-1 max-w-[240px] font-mono text-xs text-indigo-100/90">
+                  <p
+                    class="line-clamp-1 max-w-[200px] font-mono text-xs text-indigo-100/90 sm:max-w-[240px]"
+                    data-copy-highlight
+                  >
                     {snippet.code.split("\n")[0]}
                   </p>
                 </td>
-                <td class="px-4 py-3 text-slate-300/80">{snippet.updated_at}</td>
+                <td class="hidden px-4 py-3 text-slate-300/80 sm:table-cell">{snippet.updated_at}</td>
+                <td class="px-4 py-3 text-right sm:text-left">
+                  <button
+                    type="button"
+                    class="copy-btn inline-flex items-center gap-1 rounded-full bg-indigo-500 px-3 py-1.5 text-xs font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
+                    data-copy-code={snippet.code}
+                  >
+                    <span aria-hidden="true">📋</span>
+                    <span class="copy-label">コピー</span>
+                  </button>
+                </td>
                 <td class="px-4 py-3 text-right">
                   <a
                     class="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"


### PR DESCRIPTION
### Motivation
- Make the table usable on narrow screens by showing only the most relevant columns (Title, Preview, copy, details) on mobile.
- Allow quick copying of snippet code directly from table rows and highlight the preview when copying.
- Reduce horizontal scrolling caused by many table columns on small viewports.

### Description
- Updated table layout: added `w-full` and hid `Category`, `Type`, `Tags`, and `Updated` columns on small screens with `hidden sm:table-cell` classes.
- Added a per-row copy button with `class="copy-btn"` and `data-copy-code={snippet.code}` and a `Copy` header column for the button.
- Marked each row with `data-copy-scope` and the preview cell with `data-copy-highlight`, and adjusted preview sizing to `max-w-[200px] sm:max-w-[240px]` to improve mobile fit.
- Minor header/alignment tweaks so the action buttons render cleanly on small screens.

### Testing
- Started the dev server via `pnpm dev` which produced the Astro ready logs (server launched successfully).
- Attempted an automated Playwright run to capture a mobile screenshot, but the headless Chromium process crashed (SIGSEGV) and the Playwright script failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695327bbe6cc83218edb0cac43d3b807)