### PR TITLE
Simplify footer and card UI (remove descriptions, tags and shortcut labels)

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -23,7 +23,6 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
     <div>
       <p class="text-xs uppercase tracking-[0.2em] text-indigo-200">{snippet.category}</p>
       <h3 class="mt-1 text-xl font-semibold text-white">{snippet.title}</h3>
-      <p class="mt-1 text-sm text-slate-200/80">{snippet.description}</p>
     </div>
     <span class="rounded-full bg-indigo-500/20 px-3 py-1 text-[11px] font-semibold text-indigo-50 ring-1 ring-indigo-300/40">
       {snippet.type}
@@ -43,14 +42,8 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
         </span>
       </summary>
       <pre class="mt-3 whitespace-pre-wrap font-mono">{snippet.code}</pre>
-      <p class="mt-2 text-[11px] text-slate-200/70">全文は詳細で閲覧できます。</p>
     </details>
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <div class="flex flex-wrap gap-2">
-        {snippet.tags.map((tag) => (
-          <span class="rounded-full bg-white/10 px-2 py-0.5 text-[11px] font-semibold text-indigo-50 ring-1 ring-white/10">{tag}</span>
-        ))}
-      </div>
       <div class="flex flex-wrap items-center gap-2">
         <a
           class="rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
@@ -69,7 +62,6 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
             <span aria-hidden="true">📋</span>
             <span class="copy-label">コピー</span>
           </button>
-          <span class="text-[10px] font-semibold text-slate-200/70">⌘/Ctrl + C</span>
         </div>
       </div>
     </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,9 +27,7 @@ const buildTimestampLabel = buildTimestamp.toLocaleString("ja-JP", { timeZone: "
     </main>
     <footer class="mx-auto max-w-6xl px-6 pb-10">
       <div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/80">
-        <p class="font-semibold text-white">Astro Snippet Library</p>
-        <p class="mt-2">CSV データを静的ビルドで読み込み、検索・コピーできるミニマル実装です。</p>
-        <p class="mt-4 text-xs text-slate-200/60">Build: {buildTimestampLabel} (JST)</p>
+        <p class="text-xs text-slate-200/60">Build: {buildTimestampLabel} (JST)</p>
       </div>
     </footer>
     <script src={`${import.meta.env.BASE_URL}scripts/copy.client.js`}></script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -293,7 +293,6 @@ const modalSnippets = snippets.map((snippet) => ({
         <div class="flex flex-wrap items-center justify-between gap-3">
           <p class="text-sm font-semibold text-white">code</p>
           <div class="flex items-center gap-3">
-            <span class="text-xs font-semibold text-slate-200/70">⌘/Ctrl + C</span>
             <button
               class="copy-btn inline-flex items-center gap-2 rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
               type="button"
@@ -310,7 +309,6 @@ const modalSnippets = snippets.map((snippet) => ({
           class="whitespace-pre-wrap rounded-xl border border-white/10 bg-slate-900/80 p-4 text-sm font-mono text-indigo-100 transition duration-300"
           data-copy-highlight
         ></pre>
-        <div id="snippet-modal-tags" class="flex flex-wrap gap-2"></div>
       </div>
 
       <div class="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-5">
@@ -587,7 +585,6 @@ const modalSnippets = snippets.map((snippet) => ({
       const modalCreated = document.querySelector("#snippet-modal-created");
       const modalUpdated = document.querySelector("#snippet-modal-updated");
       const modalCode = document.querySelector("#snippet-modal-code");
-      const modalTags = document.querySelector("#snippet-modal-tags");
       const modalRelated = document.querySelector("#snippet-modal-related");
       const modalRelatedCount = document.querySelector("#snippet-modal-related-count");
       const modalCopy = document.querySelector("#snippet-modal-copy");
@@ -665,17 +662,6 @@ const modalSnippets = snippets.map((snippet) => ({
         if (modalCode) modalCode.textContent = snippet.code;
         if (modalCopy) modalCopy.dataset.copyCode = snippet.code;
         if (modalLink) modalLink.href = `${baseUrl}snippets/${snippet.slug}/`;
-
-        if (modalTags) {
-          modalTags.innerHTML = "";
-          snippet.tags.forEach((tag) => {
-            const tagEl = document.createElement("span");
-            tagEl.className =
-              "rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-indigo-50 ring-1 ring-white/10";
-            tagEl.textContent = tag;
-            modalTags.appendChild(tagEl);
-          });
-        }
 
         renderRelatedSnippets(snippet);
         bindOpenButtons(snippetModal);


### PR DESCRIPTION
### Motivation
- Reduce footer clutter by removing static site title and description, leaving only the build timestamp for clarity.  
- Simplify card UI to show only category and title, removing secondary description text.  
- Remove tag chips and copy shortcut labels from both cards and the snippet modal to produce a minimal UI.  
- Remove modal tag rendering and related DOM manipulation since tags are no longer shown in the modal.

### Description
- Updated `src/layouts/BaseLayout.astro` to remove title/description lines from the footer and keep only the build timestamp (`Build: {buildTimestampLabel} (JST)`).
- Updated `src/components/SnippetCard.astro` to remove the snippet description, tag chip rendering, and the `⌘/Ctrl + C` copy-shortcut label next to the copy button.  
- Updated `src/pages/index.astro` to remove the modal tag container and to remove references and code that populated `#snippet-modal-tags`, and removed the shortcut label in the modal's copy area.  
- Committed the changes (files modified: `src/layouts/BaseLayout.astro`, `src/components/SnippetCard.astro`, `src/pages/index.astro`).

### Testing
- Started the dev server with `pnpm dev`, and Astro reported it was ready and watching files.  
- Attempted a Playwright-based UI screenshot to validate the changes, but the browser run failed/crashed (Playwright reported `ERR_EMPTY_RESPONSE` / Chromium crash).  
- No other automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532e4b70ec8321ac3241ea27d77249)