### PR TITLE
Adjust table sizing for mobile screens

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -139,17 +139,17 @@ const modalSnippets = snippets.map((snippet) => ({
 
     <div id="snippet-table" class="hidden">
       <div class="overflow-x-auto rounded-2xl border border-white/10 bg-slate-950/40">
-        <table class="w-full min-w-full text-left text-sm text-slate-200/85">
-          <thead class="bg-white/5 text-xs uppercase tracking-[0.2em] text-indigo-200">
+        <table class="w-full min-w-full text-left text-xs text-slate-200/85 sm:text-sm">
+          <thead class="bg-white/5 text-[10px] uppercase tracking-[0.2em] text-indigo-200 sm:text-xs">
             <tr>
-              <th scope="col" class="px-4 py-3">Title</th>
+              <th scope="col" class="px-3 py-2 sm:px-4 sm:py-3">Title</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Category</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Type</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Tags</th>
-              <th scope="col" class="px-4 py-3">Preview</th>
+              <th scope="col" class="px-3 py-2 sm:px-4 sm:py-3">Preview</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Updated</th>
-              <th scope="col" class="px-4 py-3 text-right sm:text-left">Copy</th>
-              <th scope="col" class="px-4 py-3 text-right"></th>
+              <th scope="col" class="px-3 py-2 text-right sm:px-4 sm:py-3 sm:text-left">Copy</th>
+              <th scope="col" class="px-3 py-2 text-right sm:px-4 sm:py-3"></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-white/5">
@@ -168,7 +168,9 @@ const modalSnippets = snippets.map((snippet) => ({
                 data-display="table-row"
                 data-copy-scope
               >
-                <td class="px-4 py-3 font-semibold text-white">{snippet.title}</td>
+                <td class="px-3 py-2 text-xs font-semibold leading-tight text-white sm:px-4 sm:py-3 sm:text-sm">
+                  {snippet.title}
+                </td>
                 <td class="hidden px-4 py-3 text-indigo-100/90 sm:table-cell">{snippet.category}</td>
                 <td class="hidden px-4 py-3 sm:table-cell">{snippet.type}</td>
                 <td class="hidden px-4 py-3 sm:table-cell">
@@ -185,28 +187,28 @@ const modalSnippets = snippets.map((snippet) => ({
                     )}
                   </div>
                 </td>
-                <td class="px-4 py-3">
+                <td class="px-3 py-2 sm:px-4 sm:py-3">
                   <p
-                    class="line-clamp-1 max-w-[200px] font-mono text-xs text-indigo-100/90 sm:max-w-[240px]"
+                    class="max-w-[160px] whitespace-normal break-words font-mono text-[10px] leading-4 text-indigo-100/90 sm:max-w-[240px] sm:text-xs"
                     data-copy-highlight
                   >
                     {snippet.code.split("\n")[0]}
                   </p>
                 </td>
                 <td class="hidden px-4 py-3 text-slate-300/80 sm:table-cell">{snippet.updated_at}</td>
-                <td class="px-4 py-3 text-right sm:text-left">
+                <td class="px-3 py-2 text-right sm:px-4 sm:py-3 sm:text-left">
                   <button
                     type="button"
-                    class="copy-btn inline-flex items-center gap-1 rounded-full bg-indigo-500 px-3 py-1.5 text-xs font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60"
+                    class="copy-btn inline-flex items-center gap-1 rounded-full bg-indigo-500 px-2.5 py-1 text-[10px] font-semibold text-white shadow-lg shadow-indigo-500/40 transition hover:-translate-y-0.5 hover:shadow-indigo-500/60 sm:px-3 sm:py-1.5 sm:text-xs"
                     data-copy-code={snippet.code}
                   >
                     <span aria-hidden="true">📋</span>
                     <span class="copy-label">コピー</span>
                   </button>
                 </td>
-                <td class="px-4 py-3 text-right">
+                <td class="px-3 py-2 text-right sm:px-4 sm:py-3">
                   <a
-                    class="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20"
+                    class="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-2.5 py-1 text-[10px] font-semibold text-white transition hover:border-indigo-200/50 hover:bg-white/20 sm:px-3 sm:py-1.5 sm:text-xs"
                     href={withBase(`/snippets/${snippet.slug}/`)}
                     data-snippet-open
                     data-snippet-slug={snippet.slug}


### PR DESCRIPTION
### Motivation

- Make the table UI fit portrait mobile screens without horizontal scrolling by reducing paddings, typography, and action sizes. 
- Keep the desktop/tablet appearance unchanged using `sm:` responsive utilities. 
- Improve readability of the preview column by allowing wrapping and using a smaller monospace font. 

### Description

- Updated `src/pages/index.astro` to reduce header and cell typography to `text-[10px]`/`text-xs` and shrink paddings to `px-3 py-2` on small screens while preserving `sm:` sizes. 
- Made the preview column wrap with `whitespace-normal break-words` and set a smaller `max-w-[160px]` and monospace `text-[10px]` for compact display. 
- Reduced the copy and detail button sizes to `px-2.5 py-1 text-[10px]` on mobile and kept original sizing at `sm:` breakpoints. 

### Testing

- Started the dev server with `pnpm dev` which launched successfully. 
- Verified the app responded with `curl -I` to the app URL and returned `HTTP/1.1 200 OK`. 
- Attempted an automated Playwright mobile screenshot to validate layout, but it failed with `net::ERR_EMPTY_RESPONSE` when loading the dev server URL.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953311f023c83218d334b9ff18dccb3)