### PR TITLE
Disable horizontal scrolling for table view on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -138,7 +138,7 @@ const modalSnippets = snippets.map((snippet) => ({
     </div>
 
     <div id="snippet-table" class="hidden">
-      <div class="overflow-x-auto rounded-2xl border border-white/10 bg-slate-950/40">
+      <div class="overflow-x-hidden rounded-2xl border border-white/10 bg-slate-950/40">
         <table class="w-full min-w-full text-left text-xs text-slate-200/85 sm:text-sm">
           <thead class="bg-white/5 text-[10px] uppercase tracking-[0.2em] text-indigo-200 sm:text-xs">
             <tr>


### PR DESCRIPTION
### Motivation
- The table UI was allowed to horizontally scroll on small screens which breaks the intended mobile layout.
- The goal is to keep the table container fixed and prevent side-scrolling on mobile devices.

### Description
- Replaced `overflow-x-auto` with `overflow-x-hidden` on the table container in `src/pages/index.astro` to disable horizontal scrolling.
- The change affects the wrapping `div` around the `<table>` so the table no longer enables sideways scroll on narrow viewports.

### Testing
- Launched the dev server with `pnpm dev` which started successfully and served the app.
- Attempted a Playwright screenshot to validate the mobile/table view but the script timed out and did not complete.
- No other automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69545dfb59a0832181ccccfcf19126ec)