### PR TITLE
Adjust table column widths for Title and Preview

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,7 +142,7 @@ const modalSnippets = snippets.map((snippet) => ({
         <table class="w-full min-w-full text-left text-xs text-slate-200/85 sm:text-sm">
           <thead class="bg-white/5 text-[10px] uppercase tracking-[0.2em] text-indigo-200 sm:text-xs">
             <tr>
-              <th scope="col" class="px-3 py-2 sm:px-4 sm:py-3">Title</th>
+              <th scope="col" class="px-3 py-2 sm:px-4 sm:py-3 sm:w-[320px]">Title</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Category</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Type</th>
               <th scope="col" class="hidden px-4 py-3 sm:table-cell">Tags</th>
@@ -168,7 +168,7 @@ const modalSnippets = snippets.map((snippet) => ({
                 data-display="table-row"
                 data-copy-scope
               >
-                <td class="px-3 py-2 text-xs font-semibold leading-tight text-white sm:px-4 sm:py-3 sm:text-sm">
+                <td class="px-3 py-2 text-xs font-semibold leading-tight text-white sm:w-[320px] sm:px-4 sm:py-3 sm:text-sm">
                   {snippet.title}
                 </td>
                 <td class="hidden px-4 py-3 text-indigo-100/90 sm:table-cell">{snippet.category}</td>
@@ -189,7 +189,7 @@ const modalSnippets = snippets.map((snippet) => ({
                 </td>
                 <td class="px-3 py-2 sm:px-4 sm:py-3">
                   <p
-                    class="max-w-[160px] whitespace-normal break-words font-mono text-[10px] leading-4 text-indigo-100/90 sm:max-w-[240px] sm:text-xs"
+                    class="max-w-[80px] whitespace-normal break-words font-mono text-[10px] leading-4 text-indigo-100/90 sm:max-w-[120px] sm:text-xs"
                     data-copy-highlight
                   >
                     {snippet.code.split("\n")[0]}


### PR DESCRIPTION
### Motivation
- Reduce the visual width of the table `Title` column to better match requested ~60–70% sizing on desktop.  
- Shrink the `Preview` column so preview snippets occupy roughly ~50% of their previous width.  
- Keep layout responsive so changes apply on `sm` (desktop) breakpoints only.  

### Description
- Added `sm:w-[320px]` to the `Title` column header and its corresponding `td` to constrain title column width on larger screens.  
- Reduced preview snippet max widths from `max-w-[160px]`/`sm:max-w-[240px]` to `max-w-[80px]`/`sm:max-w-[120px]` to tighten the Preview column.  
- Changes applied in `src/pages/index.astro` by updating the table header, title cell, and preview paragraph classes.  

### Testing
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 4321` which launched successfully.  
- Verified HTTP response for the app root with `curl -I` and received `HTTP/1.1 200 OK`.  
- Attempted a Playwright screenshot to validate layout, but it failed with `net::ERR_EMPTY_RESPONSE`.  
- Changes were staged and committed locally to the branch and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695460801b3c8321928513d0ea8a89ef)