### PR TITLE
Reduce horizontal padding in BaseLayout to use more side space on small screens

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,10 +22,10 @@ const buildTimestampLabel = buildTimestamp.toLocaleString("ja-JP", { timeZone: "
   <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
     <div class="pointer-events-none fixed inset-0 -z-10 bg-gradient-to-br from-indigo-900/40 via-slate-900 to-slate-950"></div>
     <div class="pointer-events-none fixed inset-x-10 top-16 -z-10 h-72 rounded-full bg-gradient-to-r from-indigo-600/30 via-fuchsia-500/20 to-cyan-500/30 blur-3xl"></div>
-    <main class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-16 pt-10 sm:pt-14">
+    <main class="mx-auto flex max-w-6xl flex-col gap-12 px-4 pb-16 pt-10 sm:px-6 sm:pt-14">
       <slot />
     </main>
-    <footer class="mx-auto max-w-6xl px-6 pb-10">
+    <footer class="mx-auto max-w-6xl px-4 pb-10 sm:px-6">
       <div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/80">
         <p class="text-xs text-slate-200/60">Build: {buildTimestampLabel} (JST)</p>
       </div>


### PR DESCRIPTION
### Motivation
- Reduce excessive left/right whitespace on smaller screens so cards and search feel less narrow. 
- Keep the existing wider gutters on `sm`+ viewports to preserve the current desktop spacing.

### Description
- Updated `src/layouts/BaseLayout.astro` to change the main content padding from `px-6` to `px-4` and added `sm:px-6` so small+ screens keep the larger gutter. 
- Applied the same change to the footer by replacing `px-6` with `px-4` and adding `sm:px-6`.

### Testing
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 4321` and the server launched successfully. 
- Attempted an automated visual check with Playwright to capture a screenshot, but Chromium crashed and the screenshot step failed. 
- No other automated test suite was run for this UI-only layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546b27bbc0832193663246b3e6de62)