### PR TITLE
Tighten spacing for layout, controls, and cards

### DIFF
--- a/src/components/SnippetCard.astro
+++ b/src/components/SnippetCard.astro
@@ -6,7 +6,7 @@ const { snippet } = Astro.props as { snippet: Snippet };
 const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <article
-  class="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 shadow-lg shadow-indigo-500/10 transition hover:-translate-y-0.5 hover:border-indigo-300/30 hover:shadow-indigo-500/30"
+  class="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg shadow-indigo-500/10 transition hover:-translate-y-0.5 hover:border-indigo-300/30 hover:shadow-indigo-500/30"
   data-snippet
   data-title={snippet.title.toLowerCase()}
   data-description={snippet.description.toLowerCase()}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,11 +22,11 @@ const buildTimestampLabel = buildTimestamp.toLocaleString("ja-JP", { timeZone: "
   <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
     <div class="pointer-events-none fixed inset-0 -z-10 bg-gradient-to-br from-indigo-900/40 via-slate-900 to-slate-950"></div>
     <div class="pointer-events-none fixed inset-x-10 top-16 -z-10 h-72 rounded-full bg-gradient-to-r from-indigo-600/30 via-fuchsia-500/20 to-cyan-500/30 blur-3xl"></div>
-    <main class="mx-auto flex max-w-6xl flex-col gap-12 px-4 pb-16 pt-10 sm:px-6 sm:pt-14">
+    <main class="mx-auto flex max-w-6xl flex-col gap-8 px-3 pb-14 pt-8 sm:px-5 sm:pt-12">
       <slot />
     </main>
-    <footer class="mx-auto max-w-6xl px-4 pb-10 sm:px-6">
-      <div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/80">
+    <footer class="mx-auto max-w-6xl px-3 pb-10 sm:px-5">
+      <div class="rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-slate-200/80">
         <p class="text-xs text-slate-200/60">Build: {buildTimestampLabel} (JST)</p>
       </div>
     </footer>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ const modalSnippets = snippets.map((snippet) => ({
 ---
 <BaseLayout title="Astro Snippet Library" description="CSV から読み込むシンプルなスニペット集">
   <section
-    class="group grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 pb-20 shadow-xl shadow-indigo-500/10 sm:pb-6"
+    class="group grid gap-5 rounded-3xl border border-white/10 bg-white/5 p-4 pb-16 shadow-xl shadow-indigo-500/10 sm:gap-6 sm:p-6 sm:pb-6"
     data-controls
     data-view="card"
   >
@@ -64,7 +64,7 @@ const modalSnippets = snippets.map((snippet) => ({
       </div>
     </div>
     <div class="grid gap-3 sm:grid-cols-[2fr_1fr_1fr]">
-      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
+      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-2.5 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">🔍</span>
         <input
           id="search"
@@ -81,7 +81,7 @@ const modalSnippets = snippets.map((snippet) => ({
           クリア
         </button>
       </label>
-      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
+      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-2.5 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">📁</span>
         <select id="category" class="min-w-0 flex-1 bg-transparent text-sm outline-none">
           <option value="">すべてのカテゴリー</option>
@@ -98,7 +98,7 @@ const modalSnippets = snippets.map((snippet) => ({
           クリア
         </button>
       </label>
-      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
+      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-2.5 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">🏷️</span>
         <select id="type" class="min-w-0 flex-1 bg-transparent text-sm outline-none">
           <option value="">すべてのタイプ</option>
@@ -118,7 +118,7 @@ const modalSnippets = snippets.map((snippet) => ({
     </div>
 
     <div class="grid gap-3">
-      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner">
+      <label class="flex flex-wrap items-center gap-2 rounded-xl border border-white/10 bg-slate-950/60 px-2.5 py-2 text-sm text-slate-100 shadow-inner">
         <span class="text-indigo-200">↕️</span>
         <select id="sort" class="min-w-0 flex-1 bg-transparent text-sm outline-none">
           <option value="updated_desc">更新日が新しい順</option>

--- a/src/pages/snippets/[slug].astro
+++ b/src/pages/snippets/[slug].astro
@@ -19,7 +19,7 @@ const related = snippets
 const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
 ---
 <BaseLayout title={`${snippet.title} | Snippet`} description={snippet.description}>
-  <section class="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-indigo-500/10">
+  <section class="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 shadow-xl shadow-indigo-500/10 sm:p-6">
     <div class="flex items-start justify-between gap-4">
       <div>
         <p class="text-xs uppercase tracking-[0.2em] text-indigo-200">{snippet.category}</p>
@@ -39,7 +39,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
       </a>
     </div>
 
-    <div class="grid gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-5" data-copy-scope>
+    <div class="grid gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-4" data-copy-scope>
       <div class="flex flex-wrap items-center justify-between gap-3">
         <p class="text-sm font-semibold text-white">code</p>
         <div class="flex items-center gap-3">
@@ -68,7 +68,7 @@ const withBase = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^
     </div>
 
     {related.length > 0 && (
-      <div class="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-5">
+      <div class="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 sm:p-5">
         <div class="flex items-center justify-between">
           <h2 class="text-lg font-semibold">同じカテゴリーのスニペット</h2>
           <span class="rounded-full bg-indigo-500/20 px-3 py-1 text-xs font-semibold text-indigo-50 ring-1 ring-indigo-300/40">{related.length} 件</span>


### PR DESCRIPTION
### Motivation
- Reduce excessive gaps between background, content and cards so the UI feels tighter, especially on the horizontal axis. 
- Make filter controls and card/list layouts denser to improve information density on small screens. 
- Align snippet detail panels with the updated compact spacing so related components visually match.

### Description
- Reduced page-level spacing in `src/layouts/BaseLayout.astro` by decreasing `gap`, `px`, `pt` and footer inner padding. 
- Compactified the main controls area in `src/pages/index.astro` by lowering section `gap`, reducing card/container padding, and changing filter label `px` from `px-3` to `px-2.5`. 
- Tightened `src/components/SnippetCard.astro` by changing card `gap` from `gap-4` to `gap-3` and card padding from `p-5` to `p-4`. 
- Updated `src/pages/snippets/[slug].astro` panels to use smaller paddings so detail/code blocks and related panels line up with the new spacing. 

### Testing
- Launched the dev server with `npx astro dev --host 0.0.0.0 --port 4321` and the server started and served the site successfully. 
- Captured a mobile screenshot with Playwright which produced `artifacts/snippet-list-mobile.png` to visually confirm spacing changes. 
- Performed a quick HTTP check with `curl -I` which returned `HTTP/1.1 200 OK` for the served page. 
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546c7242dc832198eed8dc8ce9fff9)